### PR TITLE
Handle buffer variable not being set

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -165,10 +165,7 @@ cornelis = do
         AgdaResp buffer next <- liftIO $ readChan outchan
         respond buffer next
 
-  -- https://github.com/neovimhaskell/nvim-hs/issues/94
-  neovimAsync $ do
-    liftIO $ threadDelay 1e6
-    closeInfoWindows
+  neovimAsync closeInfoWindows
 
   wrapPlugin $ Plugin
     { environment = env

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,4 @@ packages:
 - .
 
 extra-deps:
-- nvim-hs-2.1.0.7
-
+- nvim-hs-2.2.0.0


### PR DESCRIPTION
I've skimmed over your code and I think that `closeInfoWindows` would also error if you have windows open where your plugin doesn't set the `cornelis_window` buffer variable. Otherwise I'll have to dive deeper to fix your issue: https://github.com/neovimhaskell/nvim-hs/issues/94