### PR TITLE
feature: optionally silence binding remapping messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ for available bindings, or slap your `<LocalLeader>` while in insert mode.
 
 #### Disabling Default Bindings
 
-If you don't all of the default bindings, add the following to your `.vimrc`:
+If you don't want any of the default bindings, add the following to your `.vimrc`:
 
 ```viml
 let g:cornelis_no_agda_input = 1
@@ -84,6 +84,13 @@ call cornelis#bind_input("nat", "ℕ")
 
 will add `<LocalLeader>nat` as an input remapping for `ℕ`.
 
+#### Silent remaps
+When opening an Agda file, a list of all the registered bindings will appear
+on the screen. To silence these messages add the following to your `.vimrc`:
+
+```viml
+let g:cornelis_silent_remap = 1
+```
 
 ### Text Objects
 
@@ -285,7 +292,6 @@ learn how to use Agda better! I can move quickly on feature requests.
 If you'd like to get involved, feel free to tackle an issue on the tracker and
 send a PR. I'd love to have you on board!
 
-
 ## Architecture
 
 Cornelis spins up a new `BufferStuff` for each Agda buffer it encounters.
@@ -297,5 +303,3 @@ For each `BufferStuff`, we also spin up a new thread, blocking on responses
 from `agda`. These responses all get redirected to a global worker thread, which
 is responsible for dispatching on each command. Commands are typesafe, parsed
 from JSON, and associated with the buffer they came from.
-
-

--- a/README.md
+++ b/README.md
@@ -84,14 +84,6 @@ call cornelis#bind_input("nat", "ℕ")
 
 will add `<LocalLeader>nat` as an input remapping for `ℕ`.
 
-#### Silent remaps
-When opening an Agda file, a list of all the registered bindings will appear
-on the screen. To silence these messages add the following to your `.vimrc`:
-
-```viml
-let g:cornelis_silent_remap = 1
-```
-
 ### Text Objects
 
 Use the `iz`/`az` text objects to operate on text between `⟨` and `⟩`. Somewhat

--- a/autoload/cornelis.vim
+++ b/autoload/cornelis.vim
@@ -1,12 +1,8 @@
 function! cornelis#bind_input(key, result)
     let str = "<buffer> <LocalLeader>" . substitute(a:key, "|", "<bar>", "g") . " " . a:result
-    if exists("g:cornelis_silent_remap") 
-	exec "silent inoremap" . str
-    	exec "silent cnoremap" . str
-    else
-	exec "inoremap" . str
-    	exec "cnoremap" . str
-    end
+    exec "silent inoremap" . str
+    exec "silent cnoremap" . str
+
     if !exists("g:agda_input")
       let g:agda_input = {}
     endif

--- a/autoload/cornelis.vim
+++ b/autoload/cornelis.vim
@@ -1,8 +1,12 @@
 function! cornelis#bind_input(key, result)
     let str = "<buffer> <LocalLeader>" . substitute(a:key, "|", "<bar>", "g") . " " . a:result
-    exec "inoremap " . str
-    exec "cnoremap " . str
-
+    if exists("g:cornelis_silent_remap") 
+	exec "silent inoremap" . str
+    	exec "silent cnoremap" . str
+    else
+	exec "inoremap" . str
+    	exec "cnoremap" . str
+    end
     if !exists("g:agda_input")
       let g:agda_input = {}
     endif
@@ -17,4 +21,3 @@ function! cornelis#bind_input(key, result)
 
     call extend(g:agda_input[a:key[0:0]], {rest : [a:result, a:result]})
 endfunction
-


### PR DESCRIPTION
When opening a file, by default Cornelis prints the list of all available bindings: 
![image](https://user-images.githubusercontent.com/48774736/179853802-3720a2d2-9222-4f23-99c1-b964e1bbc993.png)
while this is useful, it may get tedious to see at every startup.  This PR introduces a configuration option to silence these messages: just add 
```vimrc
let g:cornelis_silent_remap = 1
```
to your `.vimrc` or, in lua,
``` lua
vim.g.cornelis_silent_remap = 1
```