### PR TITLE
New `:CornelisNormalize` features: custom compute modes & normalization in holes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ exposed via the vim commands:
 :CornelisPrevGoal
 :CornelisNextGoal
 :CornelisWhyInScope
-:CornelisNormalize
+:CornelisNormalize <CM>
 :CornelisHelperFunc <RW>
 :CornelisQuestionToMeta
 ```
@@ -49,6 +49,10 @@ exposed via the vim commands:
 Commands with an `<RW>` argument take an optional normalization mode argument,
 one of `AsIs`, `Instantiated`, `HeadNormal`, `Simplified` or `Normalised`. When
 omitted, defaults to `Normalised`.
+
+Commands with a `<CM>` argument take an optional compute mode argument,
+one of `DefaultCompute`, `HeadCompute`, `IgnoreAbstract` or `UseShowInstance`.
+When omitted, defaults to `DefaultCompute`.
 
 If you need to restart the plugin (eg if Agda is stuck in a loop), you can
 restart everything via `:CornelisRestart`.

--- a/src/Cornelis/Types/Agda.hs
+++ b/src/Cornelis/Types/Agda.hs
@@ -44,7 +44,7 @@ data Rewrite =  AsIs | Instantiated | HeadNormal | Simplified | Normalised
 
 
 data ComputeMode = DefaultCompute | HeadCompute | IgnoreAbstract | UseShowInstance
-  deriving (Show, Read, Eq)
+  deriving (Show, Read, Eq, Enum, Bounded)
 
 data UseForce
   = WithForce     -- ^ Ignore additional checks, like termination/positivity...

--- a/src/Plugin.hs
+++ b/src/Plugin.hs
@@ -199,10 +199,16 @@ whyInScope thing = do
 
 doNormalize :: CommandArguments -> Maybe String -> Neovim CornelisEnv ()
 doNormalize _ ms = withComputeMode ms $ \mode ->
-  withAgda $ void $ withCurrentBuffer $ \b -> do
-    thing <- input "Normalize what? " Nothing Nothing
+  withAgda $ void $ do
+    (b , goal) <- getGoalAtCursor
     agda <- getAgda b
-    flip runIOTCM agda $ Cmd_compute_toplevel mode thing
+    case goal of
+        Nothing -> do
+            thing <- input "Normalize what? " Nothing Nothing
+            flip runIOTCM agda $ Cmd_compute_toplevel mode thing
+        Just ip -> do
+            t <- getGoalContents b $ ip_interval ip
+            flip runIOTCM agda $ Cmd_compute mode (InteractionId $ ip_id ip) noRange $ T.unpack t
 
 helperFunc :: Rewrite -> Text -> Neovim CornelisEnv ()
 helperFunc mode expr = do

--- a/src/Plugin.hs
+++ b/src/Plugin.hs
@@ -130,6 +130,8 @@ doRestart _ = do
 normalizationMode :: Neovim env Rewrite
 normalizationMode = pure HeadNormal
 
+computeMode :: Neovim env ComputeMode
+computeMode = pure DefaultCompute
 
 solveOne :: CommandArguments -> Maybe String -> Neovim CornelisEnv ()
 solveOne _ ms = withNormalizationMode ms $ \mode ->
@@ -149,6 +151,16 @@ withNormalizationMode (Just s) f =
   case readMaybe s of
     Nothing -> reportError $ "Invalid normalization mode: " <> T.pack s
     Just nm -> f nm
+
+withComputeMode :: Maybe String -> (ComputeMode -> Neovim e ()) -> Neovim e ()
+withComputeMode Nothing f = computeMode >>= f
+withComputeMode (Just s) f =
+  case readMaybe s of
+    Nothing -> reportError $ "Invalid compute mode: "
+      <> T.pack s
+      <> ", expected one of "
+      <> T.pack (show [(minBound :: ComputeMode) .. ])
+    (Just cm) -> f cm
 
 typeContext :: CommandArguments -> Maybe String -> Neovim CornelisEnv ()
 typeContext _ ms = withNormalizationMode ms $ \mode ->
@@ -185,12 +197,12 @@ whyInScope thing = do
     agda <- getAgda b
     flip runIOTCM agda $ Cmd_why_in_scope_toplevel $ T.unpack thing
 
-doNormalize :: CommandArguments -> Neovim CornelisEnv ()
-doNormalize _ = do
+doNormalize :: CommandArguments -> Maybe String -> Neovim CornelisEnv ()
+doNormalize _ ms = withComputeMode ms $ \mode ->
   withAgda $ void $ withCurrentBuffer $ \b -> do
     thing <- input "Normalize what? " Nothing Nothing
     agda <- getAgda b
-    flip runIOTCM agda $ Cmd_compute_toplevel DefaultCompute thing
+    flip runIOTCM agda $ Cmd_compute_toplevel mode thing
 
 helperFunc :: Rewrite -> Text -> Neovim CornelisEnv ()
 helperFunc mode expr = do


### PR DESCRIPTION
I was missing features from `:CornelisNormalize`, so tried my hands at implementing them:

1. The command now accepts an optional compute mode, similarly to `:CornelisTypeContext` and friends.
2. When executed from within a hole, hole contents are normalized in that hole's context.

Please tell if these are features you'd like to see in `cornelis` and whether they require any adjustments :)

Thank a lot for your hard work, it is much appreciated!