### PR TITLE
Add further customization options for info window placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,11 +271,21 @@ The max size of the info window can be set via:
 let g:cornelis_max_size = 30
 ```
 
-If you'd prefer your info window to be split vertically, you can set:
+If you'd prefer your info window to appear somewhere else, you can set
+`g:cornelis_split_location` (previously `g:cornelis_split_direction`), e.g.
 
 ```viml
-let g:cornelis_split_direction = 'Vertical'
+let g:cornelis_split_location = 'Vertical'
 ```
+
+The following configuration options are available:
+
+- `Horizontal`: The default, opens in a horizontal split respecting `splitbelow`.
+- `Vertical`: Opens in a vertical split respecting `splitright`.
+- `Top`: Opens at the top of the window.
+- `Bottom`: Opens at the bottom of the window.
+- `Left`: Opens at the left of the window.
+- `Right`: Opens at the right of the window.
 
 
 ## Contributing

--- a/src/Cornelis/Agda.hs
+++ b/src/Cornelis/Agda.hs
@@ -10,7 +10,7 @@ import           Control.Monad.IO.Class
 import           Control.Monad.State
 import           Cornelis.Debug (reportExceptions)
 import           Cornelis.InfoWin (buildInfoBuffer)
-import           Cornelis.Types
+import           Cornelis.Types hiding (Left, Right)
 import           Cornelis.Types.Agda
 import           Cornelis.Utils
 import           Data.Aeson

--- a/src/Cornelis/InfoWin.hs
+++ b/src/Cornelis/InfoWin.hs
@@ -2,6 +2,7 @@
 
 module Cornelis.InfoWin (closeInfoWindows, showInfoWindow, buildInfoBuffer) where
 
+import           Prelude hiding (Left, Right)
 import           Control.Monad (unless)
 import           Control.Monad.State.Class
 import           Cornelis.Pretty
@@ -102,9 +103,13 @@ buildInfoBuffer = do
 buildInfoWindow :: InfoBuffer -> Window -> Neovim CornelisEnv Window
 buildInfoWindow (InfoBuffer split_buf) w = savingCurrentWindow $ do
   nvim_set_current_win w
-  asks (cc_split_direction . ce_config) >>= \case
+  asks (cc_split_location . ce_config) >>= \case
     Vertical -> vim_command "vsplit"
     Horizontal -> vim_command "split"
+    Left -> vim_command "topleft vsplit"
+    Right -> vim_command "botright vsplit"
+    Top -> vim_command "topleft split"
+    Bottom -> vim_command "botright split"
   split_win <- nvim_get_current_win
   nvim_win_set_buf split_win split_buf
 
@@ -121,9 +126,13 @@ resizeInfoWin w ib = do
   t <- nvim_buf_get_lines (iw_buffer ib) 0 (-1) False
   max_size <- asks $ cc_max_height . ce_config
   let size = min max_size $ fromIntegral $ V.length t
-  asks (cc_split_direction . ce_config) >>= \case
+  asks (cc_split_location . ce_config) >>= \case
     Vertical -> pure ()
     Horizontal -> window_set_height w size
+    Left -> pure ()
+    Right -> pure ()
+    Top -> window_set_height w size
+    Bottom -> window_set_height w size
 
 
 

--- a/src/Cornelis/Types.hs
+++ b/src/Cornelis/Types.hs
@@ -74,12 +74,12 @@ data CornelisState = CornelisState
   }
   deriving Generic
 
-data SplitDirection = Vertical | Horizontal
+data SplitLocation = Vertical | Horizontal | Left | Right | Top | Bottom
   deriving (Eq, Ord, Show, Enum, Bounded, Read)
 
 data CornelisConfig = CornelisConfig
   { cc_max_height :: Int64
-  , cc_split_direction :: SplitDirection
+  , cc_split_location :: SplitLocation
   }
   deriving (Show, Generic)
 

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -19,7 +19,7 @@ import           Cornelis.Goals
 import           Cornelis.Highlighting (highlightBuffer, getLineIntervals, lookupPoint)
 import           Cornelis.InfoWin
 import           Cornelis.Offsets
-import           Cornelis.Types
+import           Cornelis.Types hiding (Left, Right)
 import           Cornelis.Utils
 import           Cornelis.Vim
 import           Data.Bifunctor


### PR DESCRIPTION
I'm fairly picky about where my error/info windows appear in my editor, so having extra knobs to tweak beyond just "use `split`" and "use `vsplit`" will be useful.

Signed-off-by: Cameron Wong <cam@camdar.io>