### PR TITLE
bugfix: stop hiding [Left]/[Right] from [Cornelis.Types]

### DIFF
--- a/src/Cornelis/Agda.hs
+++ b/src/Cornelis/Agda.hs
@@ -10,7 +10,7 @@ import           Control.Monad.IO.Class
 import           Control.Monad.State
 import           Cornelis.Debug (reportExceptions)
 import           Cornelis.InfoWin (buildInfoBuffer)
-import           Cornelis.Types hiding (Left, Right)
+import           Cornelis.Types
 import           Cornelis.Types.Agda
 import           Cornelis.Utils
 import           Data.Aeson


### PR DESCRIPTION
Looks like we missed one in a47993e.

Signed-off-by: Cameron Wong <cam@camdar.io>