### PR TITLE
Allow agda-input prefixes other than <LocalLeader>

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ insert mode. See
 [agda-input.vim](https://github.com/isovector/cornelis/blob/master/agda-input.vim)
 for available bindings, or slap your `<LocalLeader>` while in insert mode.
 
+If you'd like to use a prefix other than your `<LocalLeader>`, add the following
+to your `.vimrc`:
+
+```viml
+let g:cornelis_agda_prefix = "<Tab>" " Replace with your desired prefix
+```
 
 #### Disabling Default Bindings
 

--- a/agda-input.vim
+++ b/agda-input.vim
@@ -1,5 +1,6 @@
 if exists("*which_key#register")
-  inoremap <buffer> <localleader> <C-O>:WhichKey "agda"<CR>
+  let l:agda_prefix = get(g:, "agda_prefix", "<localleader>")
+  exec "inoremap <buffer>" . l:agda_prefix . "<C-O>:WhichKey \"agda\"<CR>"
   call which_key#register('agda', "g:agda_input")
 endif
 

--- a/agda-input.vim
+++ b/agda-input.vim
@@ -1,6 +1,6 @@
 if exists("*which_key#register")
   let l:cornelis_agda_prefix = get(g:, "cornelis_agda_prefix", "<localleader>")
-  exec "inoremap <buffer> " . l:agda_prefix . " <C-O>:WhichKey \"agda\"<CR>"
+  exec "inoremap <buffer> " . l:cornelis_agda_prefix . " <C-O>:WhichKey \"agda\"<CR>"
   call which_key#register('agda', "g:agda_input")
 endif
 

--- a/agda-input.vim
+++ b/agda-input.vim
@@ -1,6 +1,6 @@
 if exists("*which_key#register")
   let l:cornelis_agda_prefix = get(g:, "cornelis_agda_prefix", "<localleader>")
-  exec "inoremap <buffer>" . l:agda_prefix . "<C-O>:WhichKey \"agda\"<CR>"
+  exec "inoremap <buffer> " . l:agda_prefix . " <C-O>:WhichKey \"agda\"<CR>"
   call which_key#register('agda', "g:agda_input")
 endif
 

--- a/agda-input.vim
+++ b/agda-input.vim
@@ -1,5 +1,5 @@
 if exists("*which_key#register")
-  let l:agda_prefix = get(g:, "agda_prefix", "<localleader>")
+  let l:cornelis_agda_prefix = get(g:, "cornelis_agda_prefix", "<localleader>")
   exec "inoremap <buffer>" . l:agda_prefix . "<C-O>:WhichKey \"agda\"<CR>"
   call which_key#register('agda', "g:agda_input")
 endif

--- a/autoload/cornelis.vim
+++ b/autoload/cornelis.vim
@@ -1,5 +1,6 @@
 function! cornelis#bind_input(key, result)
-    let str = "<buffer> <LocalLeader>" . substitute(a:key, "|", "<bar>", "g") . " " . a:result
+    let l:agda_prefix = get(g:, "agda_prefix", "<localleader>")
+    let str = "<buffer>" . l:agda_prefix . substitute(a:key, "|", "<bar>", "g") . " " . a:result
     exec "silent inoremap" . str
     exec "silent cnoremap" . str
 

--- a/autoload/cornelis.vim
+++ b/autoload/cornelis.vim
@@ -1,5 +1,5 @@
 function! cornelis#bind_input(key, result)
-    let l:agda_prefix = get(g:, "agda_prefix", "<localleader>")
+    let l:agda_prefix = get(g:, "cornelis_agda_prefix", "<localleader>")
     let str = "<buffer>" . l:agda_prefix . substitute(a:key, "|", "<bar>", "g") . " " . a:result
     exec "silent inoremap" . str
     exec "silent cnoremap" . str

--- a/autoload/cornelis.vim
+++ b/autoload/cornelis.vim
@@ -1,6 +1,6 @@
 function! cornelis#bind_input(key, result)
     let l:agda_prefix = get(g:, "cornelis_agda_prefix", "<localleader>")
-    let str = "<buffer>" . l:agda_prefix . substitute(a:key, "|", "<bar>", "g") . " " . a:result
+    let str = "<buffer> " . l:agda_prefix . substitute(a:key, "|", "<bar>", "g") . " " . a:result
     exec "silent inoremap" . str
     exec "silent cnoremap" . str
 

--- a/autoload/cornelis.vim
+++ b/autoload/cornelis.vim
@@ -1,6 +1,6 @@
 function! cornelis#bind_input(key, result)
-    let l:agda_prefix = get(g:, "cornelis_agda_prefix", "<localleader>")
-    let str = "<buffer> " . l:agda_prefix . substitute(a:key, "|", "<bar>", "g") . " " . a:result
+    let l:cornelis_agda_prefix = get(g:, "cornelis_agda_prefix", "<localleader>")
+    let str = "<buffer> " . l:cornelis_agda_prefix . substitute(a:key, "|", "<bar>", "g") . " " . a:result
     exec "silent inoremap" . str
     exec "silent cnoremap" . str
 


### PR DESCRIPTION
More customization options can't hurt. I find my `LocalLeader` to be irritating to hit while typing, but enough other, unrelated bindings use it that I'm not comfortable changing it wholesale.