### PR TITLE
More commands: `:CornelisGive`, `:CornelisElaborate` and `:CornelisAbort`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ exposed via the vim commands:
 :CornelisTypeContext <RW>
 :CornelisTypeContextInfer <RW>
 :CornelisRefine
+:CornelisGive
+:CornelisElaborate
 :CornelisAuto
 :CornelisSolve <RW>
 :CornelisMakeCase

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ exposed via the vim commands:
 ```
 :CornelisLoad
 :CornelisGoals
+:CornelisAbort
 :CornelisTypeContext <RW>
 :CornelisTypeContextInfer <RW>
 :CornelisRefine

--- a/README.md
+++ b/README.md
@@ -17,51 +17,69 @@
 
 ## Overview
 
-`cornelis` is agda-mode, but for neovim. It's written in Haskell, which means
+`cornelis` is [agda-mode], but for neovim. It's written in Haskell, which means
 it's maintainable and significantly less likely to bit-rot like any
 vimscript/lua implementations.
 
+[agda-mode]: https://agda.readthedocs.io/en/latest/tools/emacs-mode.html
 
 ## Features
 
 It supports highlighting, goal listing, type-context, refinement, auto, solving,
 case splitting, go-to definition, normalization, and helper functions. These are
-exposed via the vim commands:
+exposed via vim commands.  Most commands have an equivalent in [agda-mode].
 
-```
-:CornelisLoad
-:CornelisGoals
-:CornelisAbort
-:CornelisTypeContext <RW>
-:CornelisTypeContextInfer <RW>
-:CornelisRefine
-:CornelisGive
-:CornelisElaborate
-:CornelisAuto
-:CornelisSolve <RW>
-:CornelisMakeCase
-:CornelisGoToDefinition
-:CornelisPrevGoal
-:CornelisNextGoal
-:CornelisWhyInScope
-:CornelisNormalize <CM>
-:CornelisHelperFunc <RW>
-:CornelisQuestionToMeta
-```
+### Global commands
+
+| Vim command | Description | Equivalent agda-mode keybinding |
+| :--- | :--- | :--- |
+| `:CornelisLoad`           | Load and type-check buffer | <kbd>C-c</kbd><kbd>C-l</kbd> |
+| `:CornelisGoals`          | Show all goals        | <kbd>C-c</kbd><kbd>C-?</kbd> |
+| `:CornelisRestart`        | Kill and restart the `agda` process | <kbd>C-c</kbd><kbd>C-x</kbd><kbd>C-r</kbd> |
+| `:CornelisAbort`          | Abort running command | <kbd>C-c</kbd><kbd>C-x</kbd><kbd>C-a</kbd> |
+| `:CornelisSolve <RW>`     | Solve constraints     | <kbd>C-c</kbd><kbd>C-s</kbd> |
+| `:CornelisGoToDefinition` | Jump to definition of name at cursor | <kbd>M-.</kbd> or middle mouse button |
+| `:CornelisPrevGoal`       | Jump to previous goal | <kbd>C-c</kbd><kbd>C-b</kbd> |
+| `:CornelisNextGoal`       | Jump to next goal     | <kbd>C-c</kbd><kbd>C-f</kbd> |
+| `:CornelisQuestionToMeta` | Expand `?`-holes to `{! !}` | _(none)_ |
+
+### Commands in context of a goal
+
+These commands can be used in context of a hole:
+
+| Vim command | Description | Equivalent agda-mode keybinding |
+| :--- | :--- | :--- |
+| `:CornelisGive`                  | Fill goal with hole contents | <kbd>C-c</kbd><kbd>C-SPC</kbd> |
+| `:CornelisRefine`                | Refine goal                  | <kbd>C-c</kbd><kbd>C-r</kbd> |
+| `:CornelisElaborate <RW>`        | Fill goal with normalized hole contents | <kbd>C-c</kbd><kbd>C-m</kbd> |
+| `:CornelisAuto`                  | [Automatic proof search]   | <kbd>C-c</kbd><kbd>C-a</kbd> |
+| `:CornelisMakeCase`              | Case split                 | <kbd>C-c</kbd><kbd>C-c</kbd> |
+| `:CornelisTypeContext <RW>`      | Show goal type and context | <kbd>C-c</kbd><kbd>C-,</kbd> |
+| `:CornelisTypeContextInfer <RW>` | Show goal type, context, and inferred type of hole contents | <kbd>C-c</kbd><kbd>C-.</kbd> |
+| `:CornelisNormalize <CM>`        | Compute normal of hole contents | <kbd>C-c</kbd><kbd>C-n</kbd> |
+| `:CornelisWhyInScope`            | Show why given name is in scope | <kbd>C-c</kbd><kbd>C-w</kbd> |
+| `:CornelisHelperFunc <RW>`       | Copy inferred type to register `"` | <kbd>C-c</kbd><kbd>C-h</kbd> |
+
+[Automatic proof search]: https://agda.readthedocs.io/en/latest/tools/auto.html#auto
 
 Commands with an `<RW>` argument take an optional normalization mode argument,
 one of `AsIs`, `Instantiated`, `HeadNormal`, `Simplified` or `Normalised`. When
 omitted, defaults to `Normalised`.
 
-Commands with a `<CM>` argument take an optional compute mode argument,
-one of `DefaultCompute`, `HeadCompute`, `IgnoreAbstract` or `UseShowInstance`.
-When omitted, defaults to `DefaultCompute`.
+Commands with a `<CM>` argument take an optional compute mode argument:
+
+| `<CM>` | Description | Equivalent agda-mode prefix |
+| :---   | :---        | :---             |
+| `DefaultCompute`  | default, used if `<CM>` is omitted                 | no prefix, default |
+| `IgnoreAbstract`  | compute normal form, ignoring `abstract`s          | <kbd>C-u</kbd> |
+| `UseShowInstance` | compute normal form of print using `show` instance | <kbd>C-u</kbd><kbd>C-u</kbd> |
+| `HeadCompute`     | compute weak-head normal form                      | <kbd>C-u</kbd><kbd>C-u</kbd><kbd>C-u</kbd> |
+
+If Agda is stuck executing a command (e.g. if normalization takes too long),
+abort the command with `:CornelisAbort`.
 
 If you need to restart the plugin (eg if Agda is stuck in a loop), you can
 restart everything via `:CornelisRestart`.
-
-`:CornelisQuestionToMeta` will replace any `?` goals with `{! !}`s.
-
 
 ### Agda Input
 

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -182,6 +182,7 @@ cornelis = do
         , $(command "CornelisMakeCase"         'doCaseSplit)      [CmdSync Async]
         , $(command "CornelisRefine"           'doRefine)         [CmdSync Async]
         , $(command "CornelisGive"             'doGive)           [CmdSync Async]
+        , $(command "CornelisElaborate"        'doElaborate)      [CmdSync Async]
         , $(command "CornelisPrevGoal"         'doPrevGoal)       [CmdSync Async]
         , $(command "CornelisNextGoal"         'doNextGoal)       [CmdSync Async]
         , $(command "CornelisGoToDefinition"   'doGotoDefinition) [CmdSync Async]

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -173,6 +173,7 @@ cornelis = do
     { environment = env
     , exports =
         [ $(command "CornelisRestart"          'doRestart)        [CmdSync Async]
+        , $(command "CornelisAbort"            'doAbort)          [CmdSync Async]
         , $(command "CornelisLoad"             'doLoad)           [CmdSync Async]
         , $(command "CornelisGoals"            'doAllGoals)       [CmdSync Async]
         , $(command "CornelisSolve"            'solveOne)         [CmdSync Async]

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -181,6 +181,7 @@ cornelis = do
         , $(command "CornelisTypeContextInfer" 'typeContextInfer) [CmdSync Async]
         , $(command "CornelisMakeCase"         'doCaseSplit)      [CmdSync Async]
         , $(command "CornelisRefine"           'doRefine)         [CmdSync Async]
+        , $(command "CornelisGive"             'doGive)           [CmdSync Async]
         , $(command "CornelisPrevGoal"         'doPrevGoal)       [CmdSync Async]
         , $(command "CornelisNextGoal"         'doNextGoal)       [CmdSync Async]
         , $(command "CornelisGoToDefinition"   'doGotoDefinition) [CmdSync Async]

--- a/src/Plugin.hs
+++ b/src/Plugin.hs
@@ -7,6 +7,7 @@
 module Plugin where
 
 import           Control.Lens
+import           Control.Monad ((>=>))
 import           Control.Monad.State.Class
 import           Control.Monad.Trans
 import           Cornelis.Agda (withCurrentBuffer, runIOTCM, withAgda, getAgda)
@@ -126,6 +127,8 @@ doRestart _ = do
   modify $ #cs_buffers .~ mempty
   liftIO $ for_ bs $ terminateProcess . a_hdl . bs_agda_proc
 
+doAbort :: CommandArguments -> Neovim CornelisEnv ()
+doAbort _ = withAgda $ withCurrentBuffer $ getAgda >=> runIOTCM Cmd_abort
 
 normalizationMode :: Neovim env Rewrite
 normalizationMode = pure HeadNormal

--- a/src/Plugin.hs
+++ b/src/Plugin.hs
@@ -186,6 +186,15 @@ refine = withAgda $ void $ withGoalAtCursor $ \b goal -> do
   t <- getGoalContents b $ ip_interval goal
   flip runIOTCM agda $ Cmd_refine_or_intro True (InteractionId $ ip_id goal) noRange $ T.unpack t
 
+doGive :: CommandArguments -> Neovim CornelisEnv ()
+doGive = const give
+
+give :: Neovim CornelisEnv ()
+give = withAgda $ void $ withGoalAtCursor $ \b goal -> do
+  agda <- getAgda b
+  t <- getGoalContents b $ ip_interval goal
+  flip runIOTCM agda $ Cmd_give WithoutForce (InteractionId $ ip_id goal) noRange $ T.unpack t
+
 doWhyInScope :: CommandArguments -> Neovim CornelisEnv ()
 doWhyInScope _ = do
   thing <- input "Why is what in scope? " Nothing Nothing

--- a/src/Plugin.hs
+++ b/src/Plugin.hs
@@ -195,6 +195,19 @@ give = withAgda $ void $ withGoalAtCursor $ \b goal -> do
   t <- getGoalContents b $ ip_interval goal
   flip runIOTCM agda $ Cmd_give WithoutForce (InteractionId $ ip_id goal) noRange $ T.unpack t
 
+doElaborate :: CommandArguments -> Maybe String-> Neovim CornelisEnv ()
+doElaborate _ ms = withNormalizationMode ms elaborate
+
+elaborate :: Rewrite -> Neovim CornelisEnv ()
+elaborate mode = withAgda $
+  void $
+    withGoalAtCursor $ \b goal -> do
+      agda <- getAgda b
+      t <- getGoalContents b $ ip_interval goal
+      flip runIOTCM agda $
+        Cmd_elaborate_give mode (InteractionId $ ip_id goal) noRange $ T.unpack t
+
+
 doWhyInScope :: CommandArguments -> Neovim CornelisEnv ()
 doWhyInScope _ = do
   thing <- input "Why is what in scope? " Nothing Nothing

--- a/test/Hello.agda
+++ b/test/Hello.agda
@@ -33,3 +33,8 @@ copattern = ?
 foo? : Bool → Bool → Set
 foo? ?f = {! !}
 
+give : Bool
+give = {! true !}
+
+elaborate : Nat
+elaborate = {! 3 !}

--- a/test/TestSpec.hs
+++ b/test/TestSpec.hs
@@ -112,3 +112,24 @@ spec = focus $ parallel $ do
        , Swap "copattern = ?" "copattern = {! !}"
        ] $ \_ b -> do
     questionToMeta b
+
+  diffSpec "give" (Seconds 5) "test/Hello.agda"
+        [ Swap "give = {! true !}" "give = true"
+        ] $ \w _ -> do
+    goto w 37 11
+    give
+
+  let elaborate_test rw changes row column =
+        let title = maybe "default mode" show rw in
+        diffSpec ("elaborate (" <> title <> ")") (Seconds 5) "test/Hello.agda" changes $
+            \w _ -> do
+                goto w row column
+                withNormalizationMode rw elaborate
+
+  elaborate_test Nothing
+    [Swap "elaborate = {! 3 !}" "elaborate = suc (suc (suc zero))"]
+    30 16
+
+  elaborate_test (Just "AsIs")
+    [Swap "elaborate = {! 3 !}" "elaborate = 3"]
+    30 16


### PR DESCRIPTION
`Cmd_give` and friends are useful when attempting to fill holes, since they print errors explaining why unification failed.

I implemented "Give" and "Elaborate goal", and added the ability to abort a command (since I tend to accidentally normalize huge terms).

The last commit adds some documentation for all commands and points to the Emacs agda-mode equivalents.