### PR TITLE
Fix broken testsuite

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,19 @@
+# Working on cornelis
+
+The project can be built and tested with both `stack` and `cabal`.  In order to
+successfully run the test suite, `nvim` needs to be on the `$PATH`.
+
+## Development using Nix
+
+Nix integration is provided in the form of a Nix Flake.  To build the project,
+simply run `nix build`.  For interactive development, use one of the provided
+shells:
+
+```sh
+# Launch a shell with all development dependencies installed
+# (stack, system libraries, etc.):
+nix develop
+
+# Run tests from a shell that includes a Neovim binary:
+nix develop '.#testShell' --command stack test
+```

--- a/cornelis.cabal
+++ b/cornelis.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
@@ -106,8 +106,8 @@ library
     , lens
     , levenshtein
     , mtl
-    , nvim-hs
-    , nvim-hs-contrib
+    , nvim-hs >=2.0 && <3
+    , nvim-hs-contrib >=2.0 && <3
     , prettyprinter
     , process
     , random
@@ -189,8 +189,8 @@ executable cornelis
     , lens
     , levenshtein
     , mtl
-    , nvim-hs
-    , nvim-hs-contrib
+    , nvim-hs >=2.0 && <3
+    , nvim-hs-contrib >=2.0 && <3
     , prettyprinter
     , process
     , random
@@ -276,8 +276,8 @@ test-suite test
     , lens
     , levenshtein
     , mtl
-    , nvim-hs
-    , nvim-hs-contrib
+    , nvim-hs >=2.0 && <3
+    , nvim-hs-contrib >=2.0 && <3
     , prettyprinter
     , process
     , random

--- a/cornelis.cabal
+++ b/cornelis.cabal
@@ -98,6 +98,7 @@ library
     , bytestring
     , containers
     , directory
+    , either ==5.*
     , filepath
     , fingertree
     , generic-lens
@@ -178,6 +179,7 @@ executable cornelis
     , containers
     , cornelis
     , directory
+    , either ==5.*
     , filepath
     , fingertree
     , generic-lens
@@ -263,6 +265,7 @@ test-suite test
     , containers
     , cornelis
     , directory
+    , either ==5.*
     , filepath
     , fingertree
     , generic-lens

--- a/cornelis.cabal
+++ b/cornelis.cabal
@@ -92,8 +92,7 @@ library
       TypeSynonymInstances
   ghc-options: -Wall
   build-depends:
-      QuickCheck
-    , aeson
+      aeson
     , async
     , base >=4.7 && <5
     , bytestring
@@ -102,9 +101,7 @@ library
     , filepath
     , fingertree
     , generic-lens
-    , hspec
     , lens
-    , levenshtein
     , mtl
     , nvim-hs >=2.0 && <3
     , nvim-hs-contrib >=2.0 && <3
@@ -174,8 +171,7 @@ executable cornelis
       TypeSynonymInstances
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      QuickCheck
-    , aeson
+      aeson
     , async
     , base >=4.7 && <5
     , bytestring
@@ -185,9 +181,7 @@ executable cornelis
     , filepath
     , fingertree
     , generic-lens
-    , hspec
     , lens
-    , levenshtein
     , mtl
     , nvim-hs >=2.0 && <3
     , nvim-hs-contrib >=2.0 && <3

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
       let
         pkgs = import nixpkgs { inherit system; };
 
-        hsPkgs = pkgs.haskell.packages.${compiler}.override {
+        haskellPackages = pkgs.haskell.packages.${compiler}.override {
           overrides = hfinal: hprev: {
             cornelis = hfinal.callCabal2nix "cornelis" ./. { };
           };
@@ -32,7 +32,7 @@
       in
       rec {
         packages = flake-utils.lib.flattenTree {
-          cornelis = hsPkgs.cornelis;
+          cornelis = haskellPackages.cornelis;
           cornelis-vim = pkgs.vimUtils.buildVimPlugin {
             name = "cornelis";
             src = ./.;
@@ -44,5 +44,10 @@
           cornelis = flake-utils.lib.mkApp { name = "cornelis"; drv = packages.cornelis; };
         };
         defaultApp = app.cornelis;
+
+        devShells = import ./nix/dev-shells.nix {
+          inherit pkgs haskellPackages;
+          packages = p: [ defaultPackage ];
+        };
       });
 }

--- a/nix/dev-shells.nix
+++ b/nix/dev-shells.nix
@@ -1,0 +1,45 @@
+{ pkgs,
+  haskellPackages ? pkgs.haskellPackages,
+  packages,
+  ...
+}:
+let
+  # Wrap `stack` so that `stack --nix` is executed by default:
+  stack = pkgs.symlinkJoin {
+    name = "stack-nix";
+    paths = [ pkgs.stack ];
+    buildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/stack --add-flags "--nix --no-nix-pure"
+      '';
+  };
+
+  buildInputs = [
+    stack
+    pkgs.pkgconfig
+    pkgs.zlib.dev
+    pkgs.zlib.out
+    pkgs.icu
+  ];
+
+  extraTestInputs = [
+    pkgs.agda
+    pkgs.neovim
+  ];
+
+  mkShell = buildInputs:
+    haskellPackages.shellFor {
+      inherit packages buildInputs;
+
+      # Ensure nix commands do not use the global <nixpkgs> channel:
+      NIX_PATH = "nixpkgs=" + pkgs.path;
+
+      # Ensure system libraries (zlib.so, etc.) are visible to GHC:
+      LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+    };
+in
+
+{
+  default = mkShell buildInputs;
+  testShell = mkShell (buildInputs ++ extraTestInputs);
+}

--- a/package.yaml
+++ b/package.yaml
@@ -43,10 +43,6 @@ dependencies:
 - vector
 - random
 
-- hspec
-- QuickCheck
-- levenshtein
-
 default-extensions:
   - BangPatterns
   - BinaryLiterals
@@ -124,5 +120,8 @@ tests:
     dependencies:
     - cornelis
     - hspec
+    - QuickCheck
+    - levenshtein
+
     # build-dependencies:
     # - hspec-discover

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ dependencies:
 - prettyprinter
 - vector
 - random
+- either >= 5 && < 6
 
 default-extensions:
   - BangPatterns

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+( import
+  ( let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  ) { src =  ./.; }
+).shellNix

--- a/src/Cornelis/Vim.hs
+++ b/src/Cornelis/Vim.hs
@@ -8,6 +8,7 @@ import           Control.Lens
 import           Cornelis.Offsets
 import           Cornelis.Types
 import           Cornelis.Utils (objectToInt, savingCurrentPosition, savingCurrentWindow)
+import           Data.Either.Combinators (rightToMaybe)
 import           Data.Foldable (toList)
 import           Data.Int
 import qualified Data.Text as T
@@ -127,6 +128,12 @@ setreg reg val
     [ ObjectString $ encodeUtf8 reg
     , ObjectString $ encodeUtf8 val
     ]
+
+getreg :: Text -> Neovim env (Maybe Text)
+getreg reg
+    = (rightToMaybe . fromObject)
+    <$> (vim_call_function "getreg" $ V.singleton $ toObject reg)
+
 
 ------------------------------------------------------------------------------
 -- | Awful function that does the motion in visual mode and gives you back

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,6 @@ packages:
 - .
 
 extra-deps:
-- nvim-hs-2.2.0.0
-- levenshtein-0.1.3.0
+- nvim-hs-2.2.0.2
+- levenshtein-0.2.1.0
+- template-haskell-compat-v0208-0.1.9

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,22 +5,29 @@
 
 packages:
 - completed:
-    hackage: nvim-hs-2.2.0.0@sha256:df5892a4db9056cb8a1704500b466412095e7b047d6952b0b6e5a1bb2318aeaf,7632
     pantry-tree:
+      sha256: 2bc6de35f495b51b693a6ba8abcb4c43c9d34c675e0a5fee29e4b0e7d197a747
       size: 3030
-      sha256: 06e59dd210cfdf830cc405ebc5d91cb6f9a0c66b81e113b89d5b26f3c6d14453
+    hackage: nvim-hs-2.2.0.2@sha256:f8170dcceb16d89992019eea0b186fd657d227fa7424ad7366219ee3ae6e9be8,7641
   original:
-    hackage: nvim-hs-2.2.0.0
+    hackage: nvim-hs-2.2.0.2
 - completed:
-    hackage: levenshtein-0.1.3.0@sha256:b285d0fde053c4c45c86f8ea082f2e3af6ddc6ff5e0891ad23305f6123fe015a,1771
     pantry-tree:
-      size: 460
-      sha256: 0ba9ab3e59c31ee87da888f9823f34318cf775f3bf04facf523b1e7df4f1f929
+      sha256: 3e434189fe6cb6eaf1a995f913fb9884c05f0e57b4e3a449eb455c42a4992232
+      size: 527
+    hackage: levenshtein-0.2.1.0@sha256:3378358365f26dec549289f741338cc44470aef3f9de85e662b2646fe6b4fb47,2123
   original:
-    hackage: levenshtein-0.1.3.0
+    hackage: levenshtein-0.2.1.0
+- completed:
+    pantry-tree:
+      sha256: 6ccef12b43fd6561c5e74f618e4eb9200c44966127144a5056d42d1d1378118b
+      size: 295
+    hackage: template-haskell-compat-v0208-0.1.9@sha256:abba2d89c500b0ad6259f42be07c1a59d331970624de7e0600ba62738e2c0115,1523
+  original:
+    hackage: template-haskell-compat-v0208-0.1.9
 snapshots:
 - completed:
+    sha256: cdead65fca0323144b346c94286186f4969bf85594d649c49c7557295675d8a5
     size: 586286
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/16.yaml
-    sha256: cdead65fca0323144b346c94286186f4969bf85594d649c49c7557295675d8a5
   original: lts-18.16

--- a/test/Hello.agda
+++ b/test/Hello.agda
@@ -36,5 +36,9 @@ foo? ?f = {! !}
 give : Bool
 give = {! true !}
 
-elaborate : Nat
-elaborate = {! 3 !}
+not : Bool → Bool
+not true = false
+not false = true
+
+elaborate : Bool
+elaborate = {! not true !}

--- a/test/TestSpec.hs
+++ b/test/TestSpec.hs
@@ -133,10 +133,10 @@ spec = focus $ parallel $ do
                 goto w row column
                 withNormalizationMode rw elaborate
 
-  elaborate_test Nothing
-    [Swap "elaborate = {! 3 !}" "elaborate = suc (suc (suc zero))"]
-    30 16
+  elaborate_test (Just "Normalised")
+    [Swap "elaborate = {! not true !}" "elaborate = false"]
+    44 16
 
   elaborate_test (Just "AsIs")
-    [Swap "elaborate = {! 3 !}" "elaborate = 3"]
-    30 16
+    [Swap "elaborate = {! not true !}" "elaborate = not true"]
+    44 16

--- a/test/TestSpec.hs
+++ b/test/TestSpec.hs
@@ -5,7 +5,6 @@
 module TestSpec where
 
 import           Control.Concurrent (threadDelay)
-import           Control.Monad (void)
 import           Cornelis.Types
 import           Cornelis.Types.Agda (Rewrite (..))
 import           Cornelis.Utils (withBufferStuff)
@@ -20,7 +19,6 @@ import           System.Exit (ExitCode(..))
 import           System.Process (rawSystem)
 import           Test.Hspec
 import           Utils
-
 
 broken :: SpecWith a -> SpecWith a
 broken = before_ pending
@@ -37,12 +35,12 @@ spec = focus $ parallel $ do
     goto w 11 8
     refine
 
-  diffSpec "should support helper functions" (Seconds 5) "test/Hello.agda"
-      [ Swap "" "help_me : Unit"] $ \w _ -> do
+  vimSpec "should support helper functions" (Seconds 5) "test/Hello.agda" $ \w _ -> do
     goto w 11 8
     helperFunc Normalised "help_me"
     liftIO $ threadDelay 5e5
-    void $ vim_command "normal! G\"\"p"
+    reg <- getreg "\""
+    liftIO $ reg `shouldBe` (Just "help_me : Unit")
 
   broken $ diffSpec "should case split (unicode lambda)" (Seconds 5) "test/Hello.agda"
       [ Add                       "slap = λ { true → {! !}"

--- a/test/TestSpec.hs
+++ b/test/TestSpec.hs
@@ -16,6 +16,8 @@ import           Neovim (liftIO)
 import           Neovim.API.Text
 import           Neovim.Test
 import           Plugin
+import           System.Exit (ExitCode(..))
+import           System.Process (rawSystem)
 import           Test.Hspec
 import           Utils
 
@@ -25,6 +27,11 @@ broken = before_ pending
 
 spec :: Spec
 spec = focus $ parallel $ do
+  describe "nvim" $ do
+    exit_code <- runIO $ rawSystem "nvim" ["--version"]
+    it "is executable" $ do
+      exit_code `shouldBe` ExitSuccess
+
   diffSpec "should refine" (Seconds 5) "test/Hello.agda"
       [ Swap "unit = ?" "unit = one"] $ \w _ -> do
     goto w 11 8

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -112,7 +112,7 @@ vimSpec name secs fp m = do
       withLocalEnv env $ do
         vim_command $ "edit " <> T.pack fp'
         load
-        liftIO $ threadDelay 5e5
+        liftIO $ threadDelay 1e6
         w <- vim_get_current_window
         b <- nvim_win_get_buf w
         m w b


### PR DESCRIPTION
While working on some feature, I noticed that the testsuite is kind of broken.
In particular, in the absence of a working Neovim, all the tests would magically pass.

This PR should fix the testsuite.  It will (probably) break CI, so I'm marking it as a draft.

3462922cc8f23794bac77d83519462768dce9d83 adds a `nix` shell environment, and 99a0c6b6e5aff9c7e5d1d2162a519613fa851c45 describes how to use it to run the test suite.