### PR TITLE
Fix parsing of [NormalForm] in [DisplayInfo]

### DIFF
--- a/src/Cornelis/Types.hs
+++ b/src/Cornelis/Types.hs
@@ -338,6 +338,7 @@ instance FromJSON DisplayInfo where
                 <*> (fmap (fmap ta_expr) (info .: "typeAux") <|> pure Nothing)
                 <*> info .:? "boundary"
                 <*> info .:? "outputForms"
+            "NormalForm" -> NormalForm <$> info .: "expr"
             (_ :: Text) ->
               pure $ UnknownDisplayInfo v
       (_ :: Text) -> pure $ UnknownDisplayInfo v


### PR DESCRIPTION
Agda HEAD seems to return certain normalizations in `GoalSpecific` with kind `NormalForm` as seen [here](https://github.com/agda/agda/blob/cd10c87aed3305945827a911c86e2718bbb00a5f/src/full/Agda/Interaction/JSONTop.hs#L376).

This previously led to a nasty display when running `CornelisNormalize` inside of a goal.

Signed-off-by: Cameron Wong <cam@camdar.io>