### PR TITLE
Automatically close info panel when exiting buffer

### DIFF
--- a/autoload/cornelis.vim
+++ b/autoload/cornelis.vim
@@ -18,3 +18,16 @@ function! cornelis#bind_input(key, result)
 
     call extend(g:agda_input[a:key[0:0]], {rest : [a:result, a:result]})
 endfunction
+
+function! cornelis#cleanup_and_quit()
+  CornelisCloseInfoWindows 
+  if bufnr() == 1 
+    qa
+  endif 
+endfunction
+
+augroup cornelis#Quit
+      autocmd! * <buffer>
+      autocmd QuitPre <buffer>
+        \ if len(win_findbuf(expand('<abuf>'))) == 1 | call cornelis#cleanup_and_quit() | endif
+augroup END

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -170,7 +170,6 @@ $(pure [])
 main :: IO ()
 main = neovim defaultConfig { plugins = [cornelis] }
 
-
 cornelis :: Neovim () NeovimPlugin
 cornelis = do
   env <- cornelisInit
@@ -182,27 +181,27 @@ cornelis = do
   wrapPlugin $ Plugin
     { environment = env
     , exports =
-        [ $(command "CornelisRestart"          'doRestart)        [CmdSync Async]
-        , $(command "CornelisAbort"            'doAbort)          [CmdSync Async]
-        , $(command "CornelisLoad"             'doLoad)           [CmdSync Async]
-        , $(command "CornelisGoals"            'doAllGoals)       [CmdSync Async]
-        , $(command "CornelisSolve"            'solveOne)         [CmdSync Async, rw_complete]
-        , $(command "CornelisAuto"             'autoOne)          [CmdSync Async]
-        , $(command "CornelisTypeContext"      'typeContext)      [CmdSync Async, rw_complete]
-        , $(command "CornelisTypeContextInfer" 'typeContextInfer) [CmdSync Async, rw_complete]
-        , $(command "CornelisMakeCase"         'doCaseSplit)      [CmdSync Async]
-        , $(command "CornelisRefine"           'doRefine)         [CmdSync Async]
-        , $(command "CornelisGive"             'doGive)           [CmdSync Async]
-        , $(command "CornelisElaborate"        'doElaborate)      [CmdSync Async, rw_complete]
-        , $(command "CornelisPrevGoal"         'doPrevGoal)       [CmdSync Async]
-        , $(command "CornelisNextGoal"         'doNextGoal)       [CmdSync Async]
-        , $(command "CornelisGoToDefinition"   'doGotoDefinition) [CmdSync Async]
-        , $(command "CornelisWhyInScope"       'doWhyInScope)     [CmdSync Async]
-        , $(command "CornelisNormalize"        'doNormalize)      [CmdSync Async, cm_complete]
-        , $(command "CornelisHelperFunc"       'doHelperFunc)     [CmdSync Async, rw_complete]
-        , $(command "CornelisQuestionToMeta"   'doQuestionToMeta) [CmdSync Async]
+        [ $(command "CornelisRestart"          'doRestart)          [CmdSync Async]
+        , $(command "CornelisCloseInfoWindows" 'doCloseInfoWindows) [CmdSync Async]
+        , $(command "CornelisAbort"            'doAbort)            [CmdSync Async]
+        , $(command "CornelisLoad"             'doLoad)             [CmdSync Async]
+        , $(command "CornelisGoals"            'doAllGoals)         [CmdSync Async]
+        , $(command "CornelisSolve"            'solveOne)           [CmdSync Async, rw_complete]
+        , $(command "CornelisAuto"             'autoOne)            [CmdSync Async]
+        , $(command "CornelisTypeContext"      'typeContext)        [CmdSync Async, rw_complete]
+        , $(command "CornelisTypeContextInfer" 'typeContextInfer)   [CmdSync Async, rw_complete]
+        , $(command "CornelisMakeCase"         'doCaseSplit)        [CmdSync Async]
+        , $(command "CornelisRefine"           'doRefine)           [CmdSync Async]
+        , $(command "CornelisGive"             'doGive)             [CmdSync Async]
+        , $(command "CornelisElaborate"        'doElaborate)        [CmdSync Async, rw_complete]
+        , $(command "CornelisPrevGoal"         'doPrevGoal)         [CmdSync Async]
+        , $(command "CornelisNextGoal"         'doNextGoal)         [CmdSync Async]
+        , $(command "CornelisGoToDefinition"   'doGotoDefinition)   [CmdSync Async]
+        , $(command "CornelisWhyInScope"       'doWhyInScope)       [CmdSync Async]
+        , $(command "CornelisNormalize"        'doNormalize)        [CmdSync Async, cm_complete]
+        , $(command "CornelisHelperFunc"       'doHelperFunc)       [CmdSync Async, rw_complete]
+        , $(command "CornelisQuestionToMeta"   'doQuestionToMeta)   [CmdSync Async]
         , $(function "InternalCornelisRewriteModeCompletion" 'rewriteModeCompletion) Sync
         , $(function "InternalCornelisComputeModeCompletion" 'computeModeCompletion) Sync
         ]
     }
-

--- a/src/Plugin.hs
+++ b/src/Plugin.hs
@@ -13,7 +13,7 @@ import           Control.Monad.Trans
 import           Cornelis.Agda (withCurrentBuffer, runIOTCM, withAgda, getAgda)
 import           Cornelis.Goals
 import           Cornelis.Highlighting (getExtmarks, highlightInterval)
-import           Cornelis.InfoWin (showInfoWindow)
+import           Cornelis.InfoWin (showInfoWindow, closeInfoWindows)
 import           Cornelis.Offsets
 import           Cornelis.Pretty (prettyGoals, HighlightGroup (Todo))
 import           Cornelis.Types
@@ -120,6 +120,9 @@ allGoals =
     withBufferStuff b $ \bs -> do
       goalWindow b $ bs_goals bs
 
+
+doCloseInfoWindows :: CommandArguments -> Neovim CornelisEnv ()
+doCloseInfoWindows _ = closeInfoWindows
 
 doRestart :: CommandArguments -> Neovim CornelisEnv ()
 doRestart _ = do


### PR DESCRIPTION
This pr adds `:CornelisCloseInfoWindows` (which is just a call to `closeInfoWindows`) as a "top level" command available to users and an `augroup` (pretty much copied from [coqtail.vim](https://github.com/whonore/Coqtail/blob/master/autoload/coqtail.vim#L311)) that calls `cornelis#cleanup_and_quit` when a `*.agda` buffer is closed. 
This last function calls `:CornelisCloseInfoWindows` and, if this was the last buffer, simply `qa`s to avoid vim error `E444`.  