### PR TITLE
Correctly track interaction points via extmarks

### DIFF
--- a/src/Cornelis/Goals.hs
+++ b/src/Cornelis/Goals.hs
@@ -20,6 +20,16 @@ import           Neovim
 import           Neovim.API.Text
 
 
+------------------------------------------------------------------------------
+-- | Get the spanning interval of an interaction point. If we already have
+-- highlighting information from vim, use the extmark for this goal, otherwise
+-- using the interval that Agda knows about.
+getIpInterval :: Buffer -> InteractionPoint Identity -> Neovim CornelisEnv AgdaInterval
+getIpInterval b ip = do
+  ns <- asks ce_namespace
+  maybe (pure $ ip_interval' ip) (getExtmarkIntervalById ns b) $ ip_extmark ip
+
+
 --------------------------------------------------------------------------------
 -- | Move the vim cursor to a goal in the current window
 findGoal :: Ord a => (AgdaPos -> AgdaPos -> Maybe a) -> Neovim CornelisEnv ()
@@ -103,10 +113,7 @@ withGoalAtCursor f = getGoalAtCursor >>= \case
 
 
 ------------------------------------------------------------------------------
--- | Get the contents of a goal. PRECONDITION: The given interval correctly
--- spans an interaction point.
---
--- TODO(sandy): make this call correct by construction
+-- | Get the contents of a goal.
 getGoalContents_maybe :: Buffer -> InteractionPoint Identity -> Neovim CornelisEnv (Maybe Text)
 getGoalContents_maybe b ip = do
   int <- getIpInterval b ip
@@ -118,7 +125,7 @@ getGoalContents_maybe b ip = do
 
 
 ------------------------------------------------------------------------------
--- | Like 'getGoalContents_maybe', subject to the same limitations.
+-- | Like 'getGoalContents_maybe'.
 getGoalContents :: Buffer -> InteractionPoint Identity -> Neovim CornelisEnv Text
 getGoalContents b ip = fromMaybe "" <$> getGoalContents_maybe b ip
 

--- a/src/Cornelis/Types.hs
+++ b/src/Cornelis/Types.hs
@@ -188,18 +188,19 @@ data Solution = Solution
 
 data InteractionPoint f = InteractionPoint
   { ip_id :: Int
-  , ip_interval' :: f AgdaInterval
+  , ip_intervalM :: f AgdaInterval
+  , ip_extmark :: Maybe Extmark
   } deriving Generic
 
 deriving instance Eq (f AgdaInterval) => Eq (InteractionPoint f)
 deriving instance Ord (f AgdaInterval) => Ord (InteractionPoint f)
 deriving instance Show (f AgdaInterval) => Show (InteractionPoint f)
 
-ip_interval :: InteractionPoint Identity -> AgdaInterval
-ip_interval (InteractionPoint _ (Identity i)) = i
+ip_interval' :: InteractionPoint Identity -> AgdaInterval
+ip_interval' (InteractionPoint _ (Identity i) _) = i
 
 sequenceInteractionPoint :: Applicative f => InteractionPoint f -> f (InteractionPoint Identity)
-sequenceInteractionPoint (InteractionPoint n f) = InteractionPoint <$> pure n <*> fmap Identity f
+sequenceInteractionPoint (InteractionPoint n f x) = InteractionPoint <$> pure n <*> fmap Identity f <*> pure x
 
 
 data NamedPoint = NamedPoint
@@ -222,15 +223,15 @@ instance FromJSON AgdaPos' where
 
 instance FromJSON (InteractionPoint Maybe) where
   parseJSON = withObject "InteractionPoint" $ \obj -> do
-    InteractionPoint <$> obj .: "id" <*> fmap listToMaybe (obj .: "range")
+    InteractionPoint <$> obj .: "id" <*> fmap listToMaybe (obj .: "range") <*> pure Nothing
 
 instance FromJSON (InteractionPoint Identity) where
   parseJSON = withObject "InteractionPoint" $ \obj -> do
-    InteractionPoint <$> obj .: "id" <*> fmap head (obj .: "range")
+    InteractionPoint <$> obj .: "id" <*> fmap head (obj .: "range") <*> pure Nothing
 
 instance FromJSON (InteractionPoint (Const ())) where
   parseJSON = withObject "InteractionPoint" $ \obj -> do
-    InteractionPoint <$> obj .: "id" <*> pure (Const ())
+    InteractionPoint <$> obj .: "id" <*> pure (Const ()) <*> pure Nothing
 
 instance FromJSON NamedPoint where
   parseJSON = withObject "InteractionPoint" $ \obj -> do

--- a/src/Cornelis/Vim.hs
+++ b/src/Cornelis/Vim.hs
@@ -9,7 +9,6 @@ import           Cornelis.Offsets
 import           Cornelis.Types
 import           Cornelis.Utils (objectToInt, savingCurrentPosition, savingCurrentWindow)
 import           Data.Foldable (toList)
-import           Data.Functor.Identity (Identity)
 import           Data.Int
 import qualified Data.Map as M
 import qualified Data.Text as T
@@ -123,11 +122,6 @@ setreg reg val
     [ ObjectString $ encodeUtf8 reg
     , ObjectString $ encodeUtf8 val
     ]
-
-getIpInterval :: Buffer -> InteractionPoint Identity -> Neovim CornelisEnv AgdaInterval
-getIpInterval b ip = do
-  ns <- asks ce_namespace
-  maybe (pure $ ip_interval' ip) (getExtmarkIntervalById ns b) $ ip_extmark ip
 
 getExtmarkIntervalById :: Int64 -> Buffer -> Extmark -> Neovim env AgdaInterval
 getExtmarkIntervalById ns b (Extmark x) = do


### PR DESCRIPTION
This PR attaches extmarks to interaction points, and looks them up at runtime to determine a goal's interval. This fixes a bunch of weird bugs where the buffer would have changed and we'd compute the wrong thing to replace. Additionally, it gets rid of a BIG HACK, which is always nice.

Agda sends intervals that span interaction points, which we were using as the source of truth for where goals actually are in the document. But there's a better way: extmarks! Extmarks are attached to the buffer when we do syntax highlighting, and track changes to the document when we do edits. Therefore, the intervals spanned by extmarks are a much better source of truth than the intervals that come from Agda. As a bonus, we don't need to do any logic to try to keep the two in sync.

Unfortunately life isn't quite as easy as all of that; there's a delay between getting the goals and getting the highlighting, so we need to use the Agda-provided locations as a fallback in case we don't yet have an extmark.
