### PR TITLE
Handle highlighting on modified source

### DIFF
--- a/cornelis.cabal
+++ b/cornelis.cabal
@@ -28,6 +28,7 @@ library
       Cornelis.Agda
       Cornelis.Config
       Cornelis.Debug
+      Cornelis.Diff
       Cornelis.Goals
       Cornelis.Highlighting
       Cornelis.InfoWin
@@ -99,6 +100,7 @@ library
     , base >=4.7 && <5
     , bytestring
     , containers
+    , diff-loc
     , directory
     , filepath
     , fingertree
@@ -183,6 +185,7 @@ executable cornelis
     , bytestring
     , containers
     , cornelis
+    , diff-loc
     , directory
     , filepath
     , fingertree
@@ -271,6 +274,7 @@ test-suite test
     , bytestring
     , containers
     , cornelis
+    , diff-loc
     , directory
     , filepath
     , fingertree

--- a/flake.lock
+++ b/flake.lock
@@ -72,8 +72,8 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663551060,
-        "narHash": "sha256-e2SR4cVx9p7aW/XnVsGsWZBplApA9ZJUjc0fejJhnYo=",
+        "lastModified": 1673180965,
+        "narHash": "sha256-gMhL6w9RVluvPs+irJ9n0Q1BphZm+Ek4XGn5Ow7YQ3k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "8a5b9ee7b7a2b38267c9481f5c629c015108ab0d",
@@ -86,11 +86,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1664847737,
-        "narHash": "sha256-Wxl0CtRH3Vo8+qEZ/PbCcx+9D8wEEi56tJPmROum2ss=",
+        "lastModified": 1673606088,
+        "narHash": "sha256-wdYD41UwNwPhTdMaG0AIe7fE1bAdyHe6bB4HLUqUvck=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "de80d1d04ee691279e1302a1128c082bbda3ab01",
+        "rev": "37b97ae3dd714de9a17923d004a2c5b5543dfa6d",
         "type": "github"
       },
       "original": {

--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -43,3 +43,12 @@ setlocal commentstring=--\ %s
 
 setlocal iskeyword=@,!-~,^\,,^\(,^\),^\",^\',192-255
 
+function InternalCornelisNotifyEditWrapper(bytes, buf, changedtick, srow, scol, boff, orow, ocol, olen, nrow, ncol, nlen)
+  " Swallow errors when the plugin hasn't loaded yet.
+  try
+    call InternalCornelisNotifyEdit(a:bytes, a:buf, a:changedtick, a:srow, a:scol, a:boff, a:orow, a:ocol, a:olen, a:nrow, a:ncol, a:nlen)
+  catch /^Vim\%((\a\+)\)\=:E117:/ " Function doesn't exist
+  endtry
+endfunction
+
+call luaeval("vim.api.nvim_buf_attach(0, false, {on_bytes=function(...) vim.api.nvim_call_function('InternalCornelisNotifyEditWrapper', {...}) end})")

--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,7 @@ dependencies:
 - vector
 - random
 - megaparsec
+- diff-loc
 
 - hspec
 - QuickCheck

--- a/src/Cornelis/Agda.hs
+++ b/src/Cornelis/Agda.hs
@@ -19,7 +19,7 @@ import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import           Data.Text.Lazy.Encoding (encodeUtf8)
-import           Data.Text.Lazy.IO (hGetLine)
+import qualified Data.Text.Lazy.IO as LT
 import           Neovim hiding (err)
 import           Neovim.API.Text
 import           System.IO hiding (hGetLine)
@@ -62,7 +62,7 @@ spawnAgda buffer = do
       -- On the first load, we make ourselves ready before Agda tells us anything
       void $ neovimAsync $ (whenReady (pure ()) >>) . forever $ reportExceptions $ do
         whenReady $ atomicWriteIORef ready True
-        resp <- liftIO $ hGetLine hout
+        resp <- liftIO $ LT.hGetLine hout
         chan <- asks ce_stream
         case eitherDecode @Response $ encodeUtf8 resp of
           _ | LT.null resp -> pure ()
@@ -129,6 +129,7 @@ withAgda m = do
         , bs_goto_sites = mempty
         , bs_goals = AllGoalsWarnings [] [] [] []
         , bs_info_win = iw
+        , bs_code_map = mempty
         }
       m
 

--- a/src/Cornelis/Debug.hs
+++ b/src/Cornelis/Debug.hs
@@ -1,6 +1,7 @@
 module Cornelis.Debug where
 
 import Control.Exception (catch, throw)
+import Control.Monad.IO.Class
 import System.IO.Error (isAlreadyInUseError)
 import Neovim
 import Neovim.API.String (vim_report_error)
@@ -14,7 +15,7 @@ traceMX :: Show a => String -> a -> Neovim env ()
 traceMX herald a =
   vim_report_error $ "!!!" <> herald <> ": " <> show a
 
-debug :: Show a => a -> Neovim env ()
+debug :: (Show a, MonadIO m) => a -> m ()
 debug x = liftIO $ go 100
   where
     go 0 = pure ()

--- a/src/Cornelis/Diff.hs
+++ b/src/Cornelis/Diff.hs
@@ -1,0 +1,87 @@
+-- | Maintain a Diff between the text that Agda loaded most recently
+-- and the current Vim buffer. There is one such diff for every buffer,
+-- indexed by 'BufferNum'.
+--
+-- This exports three functions:
+-- - 'resetDiff' empties the diff when reloading Agda
+-- - 'recordUpdate' adds a buffer update to the diff.
+-- - 'translateInterval' applies the Diff to an interval coming from Agda,
+--   turning it into an interval for the current buffer.
+module Cornelis.Diff
+  ( resetDiff
+  , translateInterval
+  , recordUpdate
+  , Replace(..)
+  , Colline(..)
+  , Vallee(..)
+  ) where
+
+import Data.IORef (atomicModifyIORef')
+import qualified Data.Map as Map
+import Data.Tuple (swap)
+import DiffLoc (Replace(..), Colline(..), Vallee(..))
+import qualified DiffLoc as D
+import Neovim
+import Cornelis.Offsets
+import Cornelis.Types
+
+-- | A general function for modifying Diffs, shared between the three functions below.
+modifyDiff :: BufferNum -> (Diff0 -> (Diff0, a)) -> Neovim CornelisEnv a
+modifyDiff buf f = do
+  csRef <- asks ce_state
+  liftIO $ atomicModifyIORef' csRef $ \cs ->
+    let (a, ds') = Map.alterF (fmap Just . swap . alter) buf (cs_diff cs)
+    in (cs { cs_diff = ds' }, a)
+  where
+    alter Nothing = f D.emptyDiff
+    alter (Just d) = f d
+
+-- These three functions are essentially monadic wrappers, using 'modifyDiff',
+-- around the corresponding diff-loc functions:
+--
+-- @
+-- 'D.emptyDiff' :: Diff0
+-- 'D.addDiff' :: D.Replace DPos -> Diff0 -> Diff0
+-- 'D.mapDiff' :: Diff0 -> D.Interval DPos -> Maybe (D.Interval DPos)
+-- @
+--
+-- This relies on instances of 'D.Amor' and 'D.Origin' implemented in 'Cornelis.Offsets'.
+
+-- | Reset the diff to an empty diff.
+resetDiff :: BufferNum -> Neovim CornelisEnv ()
+resetDiff buf = modifyDiff buf $ \_ -> (D.emptyDiff, ())
+
+-- | Add a buffer update (insertion or deletion) to the diff.
+-- The buffer update event coming from Vim is structured exactly how the diff-loc
+-- library expects it.
+recordUpdate :: BufferNum -> D.Replace DPos -> Neovim CornelisEnv ()
+recordUpdate buf r = modifyDiff buf $ \d -> (D.addDiff r d, ())
+
+-- | Given an interval coming from Agda (a pair of start and end positions),
+-- find the corresponding interval in the current buffer.
+-- If an edit touches the interval, return Nothing.
+translateInterval :: BufferNum -> Interval VimPos -> Neovim CornelisEnv (Maybe (Interval VimPos))
+translateInterval buf sp = modifyDiff buf $ \d -> (d, translate d)
+  where
+    translate :: Diff0 -> Maybe (Interval VimPos)
+    translate d = fmap toInterval . D.mapDiff d =<< fromInterval sp
+
+-- | Convert a Cornelis interval (pair of positions) to a diff-loc interval
+-- (start position and a vector towards the end position). This is Nothing
+-- if the end precedes the start.
+fromInterval :: Interval VimPos -> Maybe (D.Interval DPos)
+fromInterval (Interval p1 p2) = (q1 D.:..) <$> (q2 D..-.? q1)
+  where
+    q1 = fromVimPos p1
+    q2 = fromVimPos p2
+
+-- | Inverse of 'fromInterval'.
+toInterval :: D.Interval DPos -> Interval VimPos
+toInterval (q D.:.. v) = Interval (toVimPos q) (toVimPos (q D..+ v))
+
+-- | Convert from Cornelis positions to diff-loc positions.
+fromVimPos :: VimPos -> DPos
+fromVimPos (Pos l c) = Colline l c
+
+toVimPos :: DPos -> VimPos
+toVimPos (Colline l c) = Pos l c

--- a/src/Cornelis/Types.hs
+++ b/src/Cornelis/Types.hs
@@ -44,6 +44,7 @@ deriving stock instance Ord Buffer
 
 data Agda = Agda
   { a_buffer :: Buffer
+  , a_ready  :: IORef Bool
   , a_req    :: InChan String
   , a_hdl    :: ProcessHandle
   }

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -59,7 +59,7 @@ respond b (InteractionPoints ips) = do
 -- Replace a function clause
 respond b (MakeCase mkcase) = do
   doMakeCase b mkcase
-  reload
+  load
 -- Replace the interaction point with a result
 respond b (GiveAction result ip) = do
   let i = ip_id ip
@@ -68,7 +68,7 @@ respond b (GiveAction result ip) = do
     Just ip' -> do
       int <- getIpInterval b ip'
       replaceInterval b int $ replaceQuestion result
-  reload
+  load
 -- Replace the interaction point with a result
 respond b (SolveAll solutions) = do
   for_ solutions $ \(Solution i ex) ->
@@ -77,7 +77,7 @@ respond b (SolveAll solutions) = do
       Just ip -> do
         int <- getIpInterval b ip
         replaceInterval b int $ replaceQuestion ex
-  reload
+  load
 respond b ClearHighlighting = do
   -- delete what we know about goto positions and stored extmarks
   modifyBufferStuff b $ \bs -> bs

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -160,7 +160,7 @@ cornelisInit :: Neovim env CornelisEnv
 cornelisInit = do
   (inchan, outchan) <- liftIO newChan
   ns <- nvim_create_namespace "cornelis"
-  mvar <- liftIO $ newIORef $ CornelisState mempty
+  mvar <- liftIO $ newIORef $ CornelisState mempty mempty
 
   cfg <- getConfig
 
@@ -218,6 +218,7 @@ cornelis = do
         , $(function "InternalCornelisRewriteModeCompletion" 'rewriteModeCompletion) Sync
         , $(function "InternalCornelisComputeModeCompletion" 'computeModeCompletion) Sync
         , $(function "InternalCornelisDebugCommandCompletion" 'debugCommandCompletion) Sync
+        , $(function "InternalCornelisNotifyEdit" 'notifyEdit) Async
         ]
     }
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ packages:
 - .
 
 extra-deps:
+- diff-loc-0.1.0.0
 - nvim-hs-2.3.0.0
 - template-haskell-compat-v0208-0.1.9.1
 - levenshtein-0.1.3.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,29 +5,36 @@
 
 packages:
 - completed:
+    hackage: diff-loc-0.1.0.0@sha256:235a8e974da0a40f390186ff406200d99d3f3513a70eb24f28bca21ed0bacccf,1097
+    pantry-tree:
+      size: 756
+      sha256: 96f1b6135db04bac3491cc40d168c4fa62bd6591e0bffd2976f305d244fd06ba
+  original:
+    hackage: diff-loc-0.1.0.0
+- completed:
     hackage: nvim-hs-2.3.0.0@sha256:0102bfe3926387dc5431eb2d9929bc4c6f19ef5f43fc36af4f83120b426965c9,7875
     pantry-tree:
-      sha256: 358e2c685447d39f9fc9bd5ad02eb25e5c497817dae627b48cb65102743dd825
       size: 3304
+      sha256: 358e2c685447d39f9fc9bd5ad02eb25e5c497817dae627b48cb65102743dd825
   original:
     hackage: nvim-hs-2.3.0.0
 - completed:
     hackage: template-haskell-compat-v0208-0.1.9.1@sha256:73b2ab35ad5c5ec0c767a55838078a22cd05994d4a452c22bf5c0711627fffc6,1525
     pantry-tree:
-      sha256: cd15a1631082a3f206d1be72493938d6875c9797beb987725baa48205091aa94
       size: 295
+      sha256: cd15a1631082a3f206d1be72493938d6875c9797beb987725baa48205091aa94
   original:
     hackage: template-haskell-compat-v0208-0.1.9.1
 - completed:
     hackage: levenshtein-0.1.3.0@sha256:b285d0fde053c4c45c86f8ea082f2e3af6ddc6ff5e0891ad23305f6123fe015a,1771
     pantry-tree:
-      sha256: 0ba9ab3e59c31ee87da888f9823f34318cf775f3bf04facf523b1e7df4f1f929
       size: 460
+      sha256: 0ba9ab3e59c31ee87da888f9823f34318cf775f3bf04facf523b1e7df4f1f929
   original:
     hackage: levenshtein-0.1.3.0
 snapshots:
 - completed:
-    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
     size: 590100
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
   original: lts-18.28


### PR DESCRIPTION
1. We need to know exactly what text Agda has loaded, so now  `CornelisLoad` checks whether Agda is busy, and saves on load
2. We also record the interval map from `Cornelis.Highlighting` at the time of loading, and from then we record all changes to the buffer using the newly released [diff-loc library](https://hackage.haskell.org/package/diff-loc), which then maps outdated highlighting spans from Agda across those changes.