### PR TITLE
Update resolver, simplify CI, and reduce CI average runtime

### DIFF
--- a/.github/template/stack-cache/action.yml
+++ b/.github/template/stack-cache/action.yml
@@ -1,42 +1,52 @@
 name: Cache Stack dirs
-description: foo
+description: Cache Stack related directories for faster builds
 
 inputs:
-  global-stack-dir:
-    description: Path to global Stack cache
-    required: false
-    default: ~/.stack
   stack-work-dir:
     description: Path to project local Stack cache
     required: false
     default: .stack-work
+  key-always-unique:
+    description: Whether always make the cache key unique
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
 
   steps:
-    - name: Create unique key
+    - name: Setup required variables
       shell: bash
       run: |
-        echo "unique_key=$(date '+%s')" >> $GITHUB_ENV
+        if [ $RUNNER_OS = "Windows" ]; then
+          echo "global_stack_dir=~\AppData\Roaming\stack" >> $GITHUB_ENV
+        else
+          echo "global_stack_dir=~/.stack" >> $GITHUB_ENV
+        fi
 
-    - name: Cache ${{ inputs.global-stack-dir }}
+        if [ "${{ inputs.key-always-unique }}" == "true" ]; then
+          echo "unique_suffix=-$(date '+%s')" >> $GITHUB_ENV
+        else
+          echo "unique_suffix=" >> $GITHUB_ENV
+        fi
+
+    - name: Cache ${{ env.global_stack_dir }}
       uses: actions/cache@v3
       with:
-        path: ${{ inputs.global-stack-dir }}
-        key: ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ env.unique_key }}
+        path: ${{ env.global_stack_dir }}
+        key: ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}${{ env.unique_suffix }}
         restore-keys: |
-          ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-
+          ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
           ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-
           ${{ runner.os }}-stack-global-
 
-    - name: Cache .stack-work
+    - name: Cache ${{ inputs.stack-work-dir }}
       uses: actions/cache@v3
       with:
         path: ${{ inputs.stack-work-dir }}
-        key: ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}-${{ env.unique_key }}
+        key: ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}${{ env.unique_suffix }}
         restore-keys: |
-          ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}-
+          ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
           ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-
           ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml') }}-
           ${{ runner.os }}-stack-work-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,25 +12,18 @@ jobs:
     uses: ./.github/workflows/stack.yml
     with:
       os: ubuntu-22.04
-      package-manager: sudo apt
 
   stack-macos:
     name: Stack macOS
     uses: ./.github/workflows/stack.yml
     with:
       os: macos-12
-      package-manager: brew
 
   stack-windows:
     name: Stack Windows
     uses: ./.github/workflows/stack.yml
     with:
       os: windows-latest
-      global-stack-cache-dir: ~\AppData\Roaming\stack
-      package-manager: choco
-      update-path-cmd: |
-        "$env:HOMEPATH\AppData\Roaming\local\bin" >> $env:GITHUB_PATH
-        "C:\tools\neovim\nvim-win64\bin" >> $env:GITHUB_PATH
 
   # Nix CI -----------------------------------------------------------------------------------------
   nix-linux:

--- a/.github/workflows/nix-agda.yml
+++ b/.github/workflows/nix-agda.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - flake.*
+      - .github/workflows/nix-agda.yml
   pull_request:
     paths:
       - flake.*
+      - .github/workflows/nix-agda.yml
     branches: [ master ]
 
 jobs:
@@ -16,7 +18,7 @@ jobs:
       matrix:
         os: ['macos-12', 'ubuntu-22.04']
 
-    name: Build Agda
+    name: Nix Agda
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,9 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # See `ghcVersions` in `../../flake.nix`
-        # GHC 9.0.2 not included since package doesn't currently build.
-        ghc: ['8107', '924']
+        # Keep in sync with `ghcVersions` in `../../flake.nix`.
+        ghc: ['8107', '924', '944']
 
     name: Build package (ghc${{ matrix.ghc }})
     runs-on: ${{ inputs.os }}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -6,17 +6,6 @@ on:
       os:
         required: true
         type: string
-      global-stack-cache-dir:
-        required: false
-        type: string
-        default: ~/.stack
-      package-manager:
-        required: true
-        type: string
-      update-path-cmd:
-        required: false
-        type: string
-        default: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
 jobs:
   build:
@@ -27,36 +16,25 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Cache Stack dirs
+      - name: Cache Stack dirs (Linux/macOS)
+        if: runner.os != 'Windows'
+        uses: ./.github/template/stack-cache
+
+      # We set `key-always-unique` to "true" for Windows to ensure that Agda, which is build with
+      # Stack in the `test-windows` job, is added to cache. This reduces the number of times that
+      # Agda needs to be built and therefore significantly decreases average CI runtime on Windows.
+      - name: Cache Stack dirs (Windows)
+        if: runner.os == 'Windows'
         uses: ./.github/template/stack-cache
         with:
-          global-stack-dir: ${{ inputs.global-stack-cache-dir }}
+          key-always-unique: "true"
 
       - name: Build package and tests
         run: |
           stack test --no-run-tests
 
-  build-and-cache-agda:
-    needs: build
-
-    name: Build and cache Agda
-    runs-on: ${{ inputs.os }}
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Cache Stack dirs
-        uses: ./.github/template/stack-cache
-        with:
-          global-stack-dir: ${{ inputs.global-stack-cache-dir }}
-
-      - name: Build package
-        run: |
-          stack install Agda
-
   test:
-    needs: [ build, build-and-cache-agda ]
+    needs: [ build ]
 
     name: Test
     runs-on: ${{ inputs.os }}
@@ -65,31 +43,46 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Cache Stack dirs
+      - name: Cache Stack dirs (Linux/macOS)
+        if: runner.os != 'Windows'
+        uses: ./.github/template/stack-cache
+
+      # We set `key-always-unique` to "true" for Windows to ensure that Agda, which is build with
+      # Stack in the `test-windows` job, is added to cache. This reduces the number of times that
+      # Agda needs to be built and therefore significantly decreases average CI runtime on Windows.
+      - name: Cache Stack dirs (Windows)
+        if: runner.os == 'Windows'
         uses: ./.github/template/stack-cache
         with:
-          global-stack-dir: ${{ inputs.global-stack-cache-dir }}
+          key-always-unique: "true"
 
-      - name: Install test dependencies
+      # We use Nix to install test dependencies on Linux and macOS since it's much faster for Agda,
+      # and also reduces how much we need to cache with the `cache` action.
+      - name: Install Nix
+        if: runner.os != 'Windows'
+        uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install test dependencies (Windows)
+        if: runner.os == 'Windows'
         run: |
-          ${{ inputs.package-manager }} install neovim
+          choco install neovim
           stack install Agda
+          "$env:HOMEPATH\AppData\Roaming\local\bin" >> $env:GITHUB_PATH
+          "C:\tools\neovim\nvim-win64\bin" >> $env:GITHUB_PATH
 
-      - name: Update $PATH
+      - name: Create Neovim swap dirs
+        shell: bash
         run: |
-          ${{ inputs.update-path-cmd }}
-
-      - name: Create Neovim swap dirs (Linux/macOS)
-        if: ${{ !startsWith(inputs.os, 'windows') }}
-        run: |
-          mkdir -p ~/.local/share/nvim/swap
-          mkdir -p ~/.local/state/nvim/swap
-
-      - name: Create Neovim swap dirs (Windows)
-        if: ${{ startsWith(inputs.os, 'windows') }}
-        run: |
-          mkdir -p ~\AppData\Roaming\local\share\nvim\swap
-          mkdir -p ~\AppData\Roaming\local\state\nvim\swap
+          if [ $RUNNER_OS == "Windows" ]; then
+            mkdir -p ~/AppData/Roaming/local/share/nvim/swap
+            mkdir -p ~/AppData/Roaming/local/state/nvim/swap
+          else
+            mkdir -p ~/.local/share/nvim/swap
+            mkdir -p ~/.local/state/nvim/swap
+          fi
 
       # Tests can be flaky so we retry them a few times.
       - name: Run tests
@@ -98,5 +91,10 @@ jobs:
           timeout_minutes: 20
           max_attempts: 3
           retry_wait_seconds: 1
+          shell: bash
           command: |
-            stack test
+            if [ $RUNNER_OS = "Windows" ]; then
+             stack test
+            else
+              nix shell nixpkgs#agda nixpkgs#neovim -c stack test
+            fi

--- a/flake.lock
+++ b/flake.lock
@@ -5,7 +5,9 @@
         "flake-utils": [
           "flake-utils"
         ],
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1667069483,
@@ -42,11 +44,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -57,11 +59,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -71,20 +73,6 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1673180965,
-        "narHash": "sha256-gMhL6w9RVluvPs+irJ9n0Q1BphZm+Ek4XGn5Ow7YQ3k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "8a5b9ee7b7a2b38267c9481f5c629c015108ab0d",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1673606088,
         "narHash": "sha256-wdYD41UwNwPhTdMaG0AIe7fE1bAdyHe6bB4HLUqUvck=",
@@ -106,7 +94,7 @@
         "agda-stdlib": "agda-stdlib",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -9,16 +9,20 @@
     # See https://github.com/isovector/cornelis#agda-version
     agda.url = "github:agda/agda/4d36cb37f8bfb765339b808b13356d760aa6f0ec";
     agda.inputs.flake-utils.follows = "flake-utils";
+    agda.inputs.nixpkgs.follows = "nixpkgs";
     agda-stdlib = { url = "github:agda/agda-stdlib/experimental"; flake = false; };
   };
 
   outputs = { self, nixpkgs, ... }@inputs:
     let
       name = "cornelis";
-      # Update `./.github/workflows/nix.yml` if changed.
-      # Build currently failing on `ghc902`.
-      ghcVersions = map (v: "ghc${v}") [ "8107" "902" "924" ];
-      defaultGhcVersion = "ghc8107";
+      # Update `./.github/workflows/nix.yml` if changed
+      # Ensure resolver in `./stack.yaml` is in sync ith `defaultGhcVersion`.
+      ghcVersions = map (v: "ghc${v}") [ "8107" "924" "944" ];
+      defaultGhcVersion = "ghc924";
+      # We use `ghc924` as default rather than `ghc925` (which would match current GHC version of
+      # resolver) since `ghc924` is default version in `nixpkgs` and so we get benefits of binary
+      # cache.
     in
     {
       overlays = {

--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,10 @@
   outputs = { self, nixpkgs, ... }@inputs:
     let
       name = "cornelis";
-      # Update `./.github/workflows/nix.yml` if changed
-      # Ensure resolver in `./stack.yaml` is in sync ith `defaultGhcVersion`.
+      # Update `./.github/workflows/nix.yml` if changed.
+      # `ghc902` excluded due to build issues.
       ghcVersions = map (v: "ghc${v}") [ "8107" "924" "944" ];
+      # Ensure resolver in `./stack.yaml` is in sync ith `defaultGhcVersion`.
       defaultGhcVersion = "ghc924";
       # We use `ghc924` as default rather than `ghc925` (which would match current GHC version of
       # resolver) since `ghc924` is default version in `nixpkgs` and so we get benefits of binary

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,15 +1,13 @@
-# GHC 8.10.7
+# GHC 9.2.5
 # Update `defaultGHCVersion` in `./flake.nix` when updating to resolver with different GHC version.
-resolver: lts-18.28
+resolver: lts-20.06
 
 packages:
 - .
 
 extra-deps:
 - diff-loc-0.1.0.0
-- nvim-hs-2.3.0.0
-- template-haskell-compat-v0208-0.1.9.1
-- levenshtein-0.1.3.0
+- levenshtein-0.2.1.0
 
 nix:
   packages: [zlib]

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -7,34 +7,20 @@ packages:
 - completed:
     hackage: diff-loc-0.1.0.0@sha256:235a8e974da0a40f390186ff406200d99d3f3513a70eb24f28bca21ed0bacccf,1097
     pantry-tree:
-      size: 756
       sha256: 96f1b6135db04bac3491cc40d168c4fa62bd6591e0bffd2976f305d244fd06ba
+      size: 756
   original:
     hackage: diff-loc-0.1.0.0
 - completed:
-    hackage: nvim-hs-2.3.0.0@sha256:0102bfe3926387dc5431eb2d9929bc4c6f19ef5f43fc36af4f83120b426965c9,7875
+    hackage: levenshtein-0.2.1.0@sha256:3378358365f26dec549289f741338cc44470aef3f9de85e662b2646fe6b4fb47,2123
     pantry-tree:
-      size: 3304
-      sha256: 358e2c685447d39f9fc9bd5ad02eb25e5c497817dae627b48cb65102743dd825
+      sha256: 3e434189fe6cb6eaf1a995f913fb9884c05f0e57b4e3a449eb455c42a4992232
+      size: 527
   original:
-    hackage: nvim-hs-2.3.0.0
-- completed:
-    hackage: template-haskell-compat-v0208-0.1.9.1@sha256:73b2ab35ad5c5ec0c767a55838078a22cd05994d4a452c22bf5c0711627fffc6,1525
-    pantry-tree:
-      size: 295
-      sha256: cd15a1631082a3f206d1be72493938d6875c9797beb987725baa48205091aa94
-  original:
-    hackage: template-haskell-compat-v0208-0.1.9.1
-- completed:
-    hackage: levenshtein-0.1.3.0@sha256:b285d0fde053c4c45c86f8ea082f2e3af6ddc6ff5e0891ad23305f6123fe015a,1771
-    pantry-tree:
-      size: 460
-      sha256: 0ba9ab3e59c31ee87da888f9823f34318cf775f3bf04facf523b1e7df4f1f929
-  original:
-    hackage: levenshtein-0.1.3.0
+    hackage: levenshtein-0.2.1.0
 snapshots:
 - completed:
-    size: 590100
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
-    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
-  original: lts-18.28
+    sha256: 4905c93319aa94aa53da8f41d614d7bacdbfe6c63a8c6132d32e6e62f24a9af4
+    size: 649315
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/6.yaml
+  original: lts-20.6


### PR DESCRIPTION
* Updated to latest LTS, and made required changes to flake and CI.
* Changed CI to use Nix to install test dependencies (Neovim and Agda) on Linux/macOS so that the two share the same process for installing deps, and don't ever need to build Agda.
* Changed some stuff about caching works to reduce the amount of new caches that are created.