### PR TITLE
Allow configuring infoview width

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,16 @@ successfully load subsequent files.
 
 ### Configuring Cornelis' Behavior
 
-The max size of the info window can be set via:
+The max height and width of the info window can be set via:
 
 ```viml
 let g:cornelis_max_size = 30
+```
+
+and
+
+```viml
+let g:cornelis_max_width = 40
 ```
 
 If you'd prefer your info window to appear somewhere else, you can set

--- a/src/Cornelis/InfoWin.hs
+++ b/src/Cornelis/InfoWin.hs
@@ -95,6 +95,7 @@ buildInfoBuffer = do
   -- Setup things in the buffer
   void $ buffer_set_var b cornelisWindowVar $ ObjectBool True
   nvim_buf_set_option b "modifiable" $ ObjectBool False
+  nvim_buf_set_option b "filetype" $ ObjectString "agdainfo"
   pure $ InfoBuffer b
 
 
@@ -103,13 +104,15 @@ buildInfoBuffer = do
 buildInfoWindow :: InfoBuffer -> Window -> Neovim CornelisEnv Window
 buildInfoWindow (InfoBuffer split_buf) w = savingCurrentWindow $ do
   nvim_set_current_win w
+  max_height <-  asks $ T.pack . show . cc_max_height . ce_config
+  max_width <- asks $ T.pack . show . cc_max_width . ce_config
   asks (cc_split_location . ce_config) >>= \case
-    Vertical   -> vim_command "vsplit"
-    Horizontal -> vim_command "split"
-    OnLeft     -> vim_command "topleft vsplit"
-    OnRight    -> vim_command "botright vsplit"
-    OnTop      -> vim_command "topleft split"
-    OnBottom   -> vim_command "botright split"
+    Vertical   -> vim_command $ max_width <> " vsplit"
+    Horizontal -> vim_command $ max_height <> " split"
+    OnLeft     -> vim_command $ "topleft " <> max_width <> " vsplit"
+    OnRight    -> vim_command $ "botright " <> max_width <> " vsplit"
+    OnTop      -> vim_command $ "topleft " <> max_height <> " split"
+    OnBottom   -> vim_command $ "botright " <> max_height <> " split"
   split_win <- nvim_get_current_win
   nvim_win_set_buf split_win split_buf
 

--- a/src/Cornelis/Types.hs
+++ b/src/Cornelis/Types.hs
@@ -103,6 +103,7 @@ readSplitLocation s = case fmap toLower s of
 
 data CornelisConfig = CornelisConfig
   { cc_max_height :: Int64
+  , cc_max_width :: Int64
   , cc_split_location :: SplitLocation
   }
   deriving (Show, Generic)


### PR DESCRIPTION
This commit alows you to configure the width of the info window as well as the height. It also sets the filetype of the info window (as lean.nvim does), which allows for future syntax highlighting and easier scriptability using autocommands.

I also cleaned up a few things that HLS was complaining about, but I'm happy to save those changes for another commit.