### PR TITLE
Infer type of expression using `:CornelisTypeInfer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ These commands can be used in context of a hole:
 | `:CornelisAuto`                  | [Automatic proof search]   | <kbd>C-c</kbd><kbd>C-a</kbd> |
 | `:CornelisMakeCase`              | Case split                 | <kbd>C-c</kbd><kbd>C-c</kbd> |
 | `:CornelisTypeContext <RW>`      | Show goal type and context | <kbd>C-c</kbd><kbd>C-,</kbd> |
+| `:CornelisTypeInfer <RW>`        | Show inferred type of hole contents | <kbd>C-c</kbd><kbd>C-d</kbd> |
 | `:CornelisTypeContextInfer <RW>` | Show goal type, context, and inferred type of hole contents | <kbd>C-c</kbd><kbd>C-.</kbd> |
 | `:CornelisNormalize <CM>`        | Compute normal of hole contents | <kbd>C-c</kbd><kbd>C-n</kbd> |
 | `:CornelisWhyInScope`            | Show why given name is in scope | <kbd>C-c</kbd><kbd>C-w</kbd> |

--- a/src/Cornelis/Pretty.hs
+++ b/src/Cornelis/Pretty.hs
@@ -120,6 +120,8 @@ prettyGoals (HelperFunction sig) =
     , mempty
     , annotate Comment $ parens "copied to \" register"
     ] id
+prettyGoals (InferredType ty) =
+  annotate Title "Inferred Type:" <+> prettyType ty
 prettyGoals (WhyInScope msg) = pretty msg
 prettyGoals (NormalForm expr) = pretty expr
 prettyGoals (DisplayError err) = annotate Error $ pretty err

--- a/src/Cornelis/Types.hs
+++ b/src/Cornelis/Types.hs
@@ -300,6 +300,7 @@ data DisplayInfo
       , di_output_forms :: Maybe [Text]
       }
   | HelperFunction Text
+  | InferredType Type
   | DisplayError Text
   | WhyInScope Text
   | NormalForm Text
@@ -326,6 +327,8 @@ instance FromJSON DisplayInfo where
       "Error" ->
         obj .: "error" >>= \err ->
           DisplayError <$> err .: "message"
+      "InferredType" ->
+        InferredType <$> obj .: "expr"
       "WhyInScope" ->
         WhyInScope <$> obj .: "message"
       "NormalForm" ->
@@ -344,6 +347,8 @@ instance FromJSON DisplayInfo where
                 <*> info .:? "boundary"
                 <*> info .:? "outputForms"
             "NormalForm" -> NormalForm <$> info .: "expr"
+            "InferredType" ->
+              InferredType <$> info .: "expr"
             (_ :: Text) ->
               pure $ UnknownDisplayInfo v
       (_ :: Text) -> pure $ UnknownDisplayInfo v

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -199,6 +199,7 @@ cornelis = do
         , $(command "CornelisGoals"            'doAllGoals)       [CmdSync Async]
         , $(command "CornelisSolve"            'solveOne)         [CmdSync Async, rw_complete]
         , $(command "CornelisAuto"             'autoOne)          [CmdSync Async]
+        , $(command "CornelisTypeInfer"        'doTypeInfer)      [CmdSync Async]
         , $(command "CornelisTypeContext"      'typeContext)      [CmdSync Async, rw_complete]
         , $(command "CornelisTypeContextInfer" 'typeContextInfer) [CmdSync Async, rw_complete]
         , $(command "CornelisMakeCase"         'doCaseSplit)      [CmdSync Async]

--- a/test/Hello.agda
+++ b/test/Hello.agda
@@ -42,3 +42,5 @@ elaborate = {! 3 !}
 sub₀and-super⁹ : Nat
 sub₀and-super⁹ = 15
 
+infer : Bool → Bool → Bool
+infer x = {! x !}

--- a/test/TestSpec.hs
+++ b/test/TestSpec.hs
@@ -162,3 +162,11 @@ spec = focus $ do
     goto w 43 16
     incNextDigitSeq
 
+  vimSpec "should infer type of local variable" timeout "test/Hello.agda" $ \w b -> do
+    withBufferStuff b $ \bs -> do
+        goto w 46 14
+        inferType AsIs
+        liftIO $ threadDelay 5e5
+        res <- buffer_get_lines (iw_buffer $ bs_info_win bs) vimFirstLine vimLastLine False
+        liftIO $ V.toList res `shouldContain` ["Inferred Type: Bool"]
+


### PR DESCRIPTION
This implements functionality to infer the type of an expression, the equivalent of Emacs <kbd>C-c</kbd><kbd>C-d</kbd>.  When inside of a hole it infers the type of the hole contents, or prompts for input. Outside of a hole it always prompts for an expression.

I've added `withGoalContentsOrPrompt` to `Cornelis.Goal` that deals with the common pattern of "use contents of a hole if available, otherwise prompt for input". Other commands could be refactored to use this, if wanted.

---

I'm marking this as a draft since I am running into an error when parsing Agda's reply. I am not sure whether this is a bug in Agda v2.6.2.2, or caused by not properly decoding the response. Any help would be appreciated.

In a file

```agda
data Void : Set where
```

Running `:CornelisTypeInfer` and putting `Void` into the prompt results in this error:

```haskell
Object (fromList [("commandState",Object (fromList [("currentFile",Array [String "/tmp/Test.agda",String "2023-01-28T13:57:07.453907854Z"]),("interactionPoints",Array [])])),("expr",String "Set"),("kind",String "InferredType"),("time",Null)])
```