### PR TITLE
Fix Nix build and update Stack resolver and Nix flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,13 +88,31 @@
         "type": "github"
       }
     },
+    "nvim-hs-source": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675633002,
+        "narHash": "sha256-+oloouRfR0vexob6z7U9t+pHqt2qCE810JiGKb3m6NQ=",
+        "owner": "neovimhaskell",
+        "repo": "nvim-hs",
+        "rev": "eaf826d4156b0281ef7ce9dec35ba720b5c45f09",
+        "type": "github"
+      },
+      "original": {
+        "owner": "neovimhaskell",
+        "repo": "nvim-hs",
+        "rev": "eaf826d4156b0281ef7ce9dec35ba720b5c45f09",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agda": "agda",
         "agda-stdlib": "agda-stdlib",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nvim-hs-source": "nvim-hs-source"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -10,33 +10,33 @@
         ]
       },
       "locked": {
-        "lastModified": 1667069483,
-        "narHash": "sha256-/CTtf0xQ1IcExhw3wVtYfig4mIdV6D9cFebg+mqDnVk=",
+        "lastModified": 1676292415,
+        "narHash": "sha256-HEWxwLLZB7yAAa4QROH60yHMXgUDMJG6DvZaF1ho26w=",
         "owner": "agda",
         "repo": "agda",
-        "rev": "4d36cb37f8bfb765339b808b13356d760aa6f0ec",
+        "rev": "8d4416a462719bffbf21617b9f2fa00234e185ac",
         "type": "github"
       },
       "original": {
         "owner": "agda",
         "repo": "agda",
-        "rev": "4d36cb37f8bfb765339b808b13356d760aa6f0ec",
+        "rev": "8d4416a462719bffbf21617b9f2fa00234e185ac",
         "type": "github"
       }
     },
-    "agda-stdlib": {
+    "agda-stdlib-source": {
       "flake": false,
       "locked": {
-        "lastModified": 1667069530,
-        "narHash": "sha256-l2+8myyJSufXpt1Opf65AJaTMiHMDeYYbuvkvzbCjDo=",
+        "lastModified": 1675217091,
+        "narHash": "sha256-vvbyfC5+Yyx18IDikSbAAcTHHtU6krlz45Fd2YlwsBg=",
         "owner": "agda",
         "repo": "agda-stdlib",
-        "rev": "236275218f01f8e65c4ea46c1fce1a9d0bca6fd1",
+        "rev": "b2e6385c1636897dbee0b10f7194376ff2c1753b",
         "type": "github"
       },
       "original": {
         "owner": "agda",
-        "ref": "experimental",
+        "ref": "v1.7.2",
         "repo": "agda-stdlib",
         "type": "github"
       }
@@ -44,11 +44,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673606088,
-        "narHash": "sha256-wdYD41UwNwPhTdMaG0AIe7fE1bAdyHe6bB4HLUqUvck=",
+        "lastModified": 1676150441,
+        "narHash": "sha256-Nfeua9Ua/dGHOQpzOjLtkyMyW/ysQCvZJ9Dd74QQSNk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "37b97ae3dd714de9a17923d004a2c5b5543dfa6d",
+        "rev": "6d87734c880d704f6ee13e5c0fe835b98918c34e",
         "type": "github"
       },
       "original": {
@@ -108,7 +108,7 @@
     "root": {
       "inputs": {
         "agda": "agda",
-        "agda-stdlib": "agda-stdlib",
+        "agda-stdlib-source": "agda-stdlib-source",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,10 @@
     flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
 
     # See https://github.com/isovector/cornelis#agda-version
-    agda.url = "github:agda/agda/4d36cb37f8bfb765339b808b13356d760aa6f0ec";
+    agda.url = "github:agda/agda/8d4416a462719bffbf21617b9f2fa00234e185ac";
     agda.inputs.flake-utils.follows = "flake-utils";
     agda.inputs.nixpkgs.follows = "nixpkgs";
-    agda-stdlib = { url = "github:agda/agda-stdlib/experimental"; flake = false; };
+    agda-stdlib-source = { url = "github:agda/agda-stdlib/v1.7.2"; flake = false; };
 
     # TODO: Remove when `nvim-hs` hits version >= 2.3.2.2 in `nixpkgs`.
     # https://search.nixos.org/packages?channel=unstable&query=nvim-hs
@@ -69,8 +69,8 @@
         };
         agda = pkgs.agda.withPackages (p: nixpkgs.lib.singleton (
           p.standard-library.overrideAttrs (_: {
-            version = "2.0-experimental";
-            src = inputs.agda-stdlib;
+            version = "1.7.2";
+            src = inputs.agda-stdlib-source;
           })
         ));
       in

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,11 @@
     agda.inputs.flake-utils.follows = "flake-utils";
     agda.inputs.nixpkgs.follows = "nixpkgs";
     agda-stdlib = { url = "github:agda/agda-stdlib/experimental"; flake = false; };
+
+    # TODO: Remove when `nvim-hs` hits version >= 2.3.2.2 in `nixpkgs`.
+    # https://search.nixos.org/packages?channel=unstable&query=nvim-hs
+    nvim-hs-source.url = "github:neovimhaskell/nvim-hs/eaf826d4156b0281ef7ce9dec35ba720b5c45f09";
+    nvim-hs-source.flake = false;
   };
 
   outputs = { self, nixpkgs, ... }@inputs:
@@ -31,7 +36,14 @@
           haskell = prev.haskell // {
             packageOverrides = final.lib.composeExtensions
               prev.haskell.packageOverrides
-              (hfinal: _: { ${name} = hfinal.callCabal2nix name ./. { }; });
+              (hfinal: hprev: {
+                # TODO: Remove when `nvim-hs` hits version >= 2.3.2.2 in `nixpkgs`.
+                # https://search.nixos.org/packages?channel=unstable&query=nvim-hs
+                nvim-hs = final.haskell.lib.overrideSrc hprev.nvim-hs {
+                  src = inputs.nvim-hs-source;
+                };
+                ${name} = hfinal.callCabal2nix name ./. { };
+              });
           };
 
           ${name} = final.haskell.packages.${defaultGhcVersion}.${name};

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # GHC 9.2.5
 # Update `defaultGHCVersion` in `./flake.nix` when updating to resolver with different GHC version.
-resolver: lts-20.06
+resolver: lts-20.11
 
 packages:
 - .

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,8 +8,10 @@ packages:
 extra-deps:
 - diff-loc-0.1.0.0
 - levenshtein-0.2.1.0
-- git: https://github.com/isovector/nvim-hs.git
-  commit: 41aa5159f58e66a7f12f9f9b47e0d0980b817d6f
+
+# TODO: Remove when updating to LTS that includes `nvim-hs` version >= 2.3.2.2.
+- git: https://github.com/neovimhaskell/nvim-hs.git
+  commit: eaf826d4156b0281ef7ce9dec35ba720b5c45f09
 
 nix:
   packages: [zlib]

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -7,31 +7,31 @@ packages:
 - completed:
     hackage: diff-loc-0.1.0.0@sha256:235a8e974da0a40f390186ff406200d99d3f3513a70eb24f28bca21ed0bacccf,1097
     pantry-tree:
-      size: 756
       sha256: 96f1b6135db04bac3491cc40d168c4fa62bd6591e0bffd2976f305d244fd06ba
+      size: 756
   original:
     hackage: diff-loc-0.1.0.0
 - completed:
     hackage: levenshtein-0.2.1.0@sha256:3378358365f26dec549289f741338cc44470aef3f9de85e662b2646fe6b4fb47,2123
     pantry-tree:
-      size: 527
       sha256: 3e434189fe6cb6eaf1a995f913fb9884c05f0e57b4e3a449eb455c42a4992232
+      size: 527
   original:
     hackage: levenshtein-0.2.1.0
 - completed:
+    commit: eaf826d4156b0281ef7ce9dec35ba720b5c45f09
+    git: https://github.com/neovimhaskell/nvim-hs.git
     name: nvim-hs
-    version: 2.3.2.1
-    git: https://github.com/isovector/nvim-hs.git
     pantry-tree:
+      sha256: 260209ca4637599dd8695f217ecf5cb3899e0c538f8a158b797ae09c0966e068
       size: 4352
-      sha256: 6ccc9cd15e7ccf3c29df6e0821f1ea25d714fed24f6254cacb730e10d368477b
-    commit: 41aa5159f58e66a7f12f9f9b47e0d0980b817d6f
+    version: 2.3.2.2
   original:
-    git: https://github.com/isovector/nvim-hs.git
-    commit: 41aa5159f58e66a7f12f9f9b47e0d0980b817d6f
+    commit: eaf826d4156b0281ef7ce9dec35ba720b5c45f09
+    git: https://github.com/neovimhaskell/nvim-hs.git
 snapshots:
 - completed:
+    sha256: 4905c93319aa94aa53da8f41d614d7bacdbfe6c63a8c6132d32e6e62f24a9af4
     size: 649315
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/6.yaml
-    sha256: 4905c93319aa94aa53da8f41d614d7bacdbfe6c63a8c6132d32e6e62f24a9af4
   original: lts-20.6

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -31,7 +31,7 @@ packages:
     git: https://github.com/neovimhaskell/nvim-hs.git
 snapshots:
 - completed:
-    sha256: 4905c93319aa94aa53da8f41d614d7bacdbfe6c63a8c6132d32e6e62f24a9af4
-    size: 649315
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/6.yaml
-  original: lts-20.6
+    sha256: adbc602422dde10cc330175da7de8609e70afc41449a7e2d6e8b1827aa0e5008
+    size: 649342
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/11.yaml
+  original: lts-20.11


### PR DESCRIPTION
- Use `nvim-hs` version 2.3.2.2
- Update LTS and Nix flake inputs
