### PR TITLE
Specify highlight priority

### DIFF
--- a/src/Cornelis/Highlighting.hs
+++ b/src/Cornelis/Highlighting.hs
@@ -17,7 +17,6 @@ import           Cornelis.Types
 import           Cornelis.Utils
 import           Cornelis.Vim (unvimify, vimify)
 import           Data.Coerce (coerce)
-import           Data.Functor ((<&>))
 import           Data.IntervalMap.FingerTree (IntervalMap)
 import qualified Data.IntervalMap.FingerTree as IM
 import qualified Data.Map as M
@@ -143,24 +142,22 @@ setHighlight' b (Interval (Pos sl sc) (Pos el ec)) hl = do
     $ fmap (Just . coerce)
     $ nvim_buf_set_extmark b ns (from0 sl) (from0 sc)
     $ M.fromList
-    $ catMaybes
-    $ [ Just
-          ( "end_line"
-          , ObjectInt $ from0 el
-          )
-      , Just
-          ( "end_col"
-          , ObjectInt $ from0 ec
-          )
-      , hl <&> (\hl' ->
-          ( "hl_group"
-          , ObjectString
-            $ encodeUtf8
-            $ T.pack
-            $ show hl'
-          )
+    $ [ ( "end_line"
+        , ObjectInt $ from0 el
         )
-      ]
+      , ( "end_col"
+        , ObjectInt $ from0 ec
+        )
+      ] ++
+      concatMap (\hl' ->
+          [ ( "hl_group"
+            , ObjectString $ encodeUtf8 $ T.pack $ show hl'
+            )
+          , ( "priority"
+            , ObjectInt $ priority hl'
+            )
+          ])
+          hl
 
 
 highlightInterval

--- a/src/Cornelis/Pretty.hs
+++ b/src/Cornelis/Pretty.hs
@@ -64,6 +64,17 @@ data HighlightGroup
   | CornelisPragma -- ^ The argument to a pragma, e.g. @{-# OPTIONS /--foo/ -#}@
   deriving (Eq, Ord, Show, Read, Enum, Bounded)
 
+-- | Priority of the HighlightGroup. See `:h vim.highlight.priorities` for more information.
+--
+-- 100 is the default syntax highlighting priority, while 150 is reserved for diagnostics.
+priority :: HighlightGroup -> Int64
+priority CornelisError              = 150
+priority CornelisErrorWarning       = 150
+priority CornelisWarn               = 150
+priority CornelisUnsolvedMeta       = 150
+priority CornelisUnsolvedConstraint = 150
+priority _                          = 100
+
 atomToHlGroup :: Text -> Maybe HighlightGroup
 atomToHlGroup atom = M.lookup atom allHlGroups where
     stripCornelis = fromJust . T.stripPrefix "Cornelis"


### PR DESCRIPTION
This is much easier than I originally thought it would be!

I also refactored `catMaybes` into a (in my opinion) more readable version where the always-included elements in are in a separate list.

Fixes #125