### PR TITLE
Allow running load synchronously

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,19 @@
         agda = pkgs.agda.withPackages (p: [ p.standard-library ]);
       in
       {
+        devShells.default = let
+          hsPkgs = pkgs.haskell.packages.${defaultGhcVersion};
+          buildInputs = [
+            hsPkgs.ghc
+            hsPkgs.haskell-language-server
+            pkgs.cabal-install
+            pkgs.hpack
+            pkgs.zlib
+          ];
+        in pkgs.mkShell {
+          buildInputs = buildInputs;
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+        };
         packages = {
           inherit agda;
           ${name} = pkgs.${name};

--- a/src/Cornelis/Types.hs
+++ b/src/Cornelis/Types.hs
@@ -107,6 +107,8 @@ data CornelisConfig = CornelisConfig
   { cc_max_height :: Int64
   , cc_max_width :: Int64
   , cc_split_location :: SplitLocation
+  , cc_sync_load :: Bool
+  -- ^ should the "load the buffer" command be synchronous?
   }
   deriving (Show, Generic)
 

--- a/src/Cornelis/Utils.hs
+++ b/src/Cornelis/Utils.hs
@@ -31,6 +31,10 @@ objectToText :: Object -> Maybe Text
 objectToText (ObjectString w) = Just $ decodeUtf8 w
 objectToText _ = Nothing
 
+objectToBool :: Object -> Maybe Bool
+objectToBool (ObjectBool b) = Just b
+objectToBool _ = Nothing
+
 neovimAsync :: (MonadUnliftIO m) => m a -> m (Async a)
 neovimAsync m =
   withRunInIO $ \lower ->

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -196,13 +196,19 @@ cornelis = do
   let rw_complete = CmdComplete "custom,InternalCornelisRewriteModeCompletion"
       cm_complete = CmdComplete "custom,InternalCornelisComputeModeCompletion"
       debug_complete = CmdComplete "custom,InternalCornelisDebugCommandCompletion"
+  let
+    loadSyncness =
+      CmdSync $
+        if cc_sync_load $ ce_config env
+          then Sync
+          else Async
 
   wrapPlugin $ Plugin
     { environment = env
     , exports =
         [ $(command "CornelisRestart"          'doRestart)        [CmdSync Async]
         , $(command "CornelisAbort"            'doAbort)          [CmdSync Async]
-        , $(command "CornelisLoad"             'doLoad)           [CmdSync Async]
+        , $(command "CornelisLoad"             'doLoad)           [loadSyncness]
         , $(command "CornelisGoals"            'doAllGoals)       [CmdSync Async]
         , $(command "CornelisSolve"            'solveOne)         [CmdSync Async, rw_complete]
         , $(command "CornelisAuto"             'autoOne)          [CmdSync Async]


### PR DESCRIPTION
Motivation:

You can't really do much of anything else before agda finishes loading a file, so I'd rather my interface freeze to indicate that the buffer is not in a workable state.

Another big motivation is that if we can rely on load being synchronous, we can then write scripts that run load and rely on the load having completed in order to then run other commands afterwards. Concretely, I wanted to have a bind for `:CornelisLoad<CR>:CornelisQuestionToMeta<CR>`, but that doesn't currently work out of the box.

Making this PR in a somewhat WIP state since I want to get feedback:
1. if you'd accept this
2. if this is the way to make a command synchronous

Notably, I'm still not sure this actually makes the command run synchronously, because my example of `:CornelisLoad<CR>:CornelisQuestionToMeta<CR>` still doesn't work, but I'm not sure what's going wrong exactly.