### PR TITLE
Reduce closure size of Nix derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,10 @@
             packageOverrides = final.lib.composeExtensions
               prev.haskell.packageOverrides
               (hfinal: hprev: {
-                ${name} = hfinal.callCabal2nix name ./. { };
+                # Put binaries into separate output "bin" to reduce closure size.
+                # https://nixos.org/manual/nixpkgs/stable/#haskell-packaging-helpers
+                ${name} = final.haskell.lib.enableSeparateBinOutput
+                  (hfinal.callCabal2nix name ./. { });
               });
           };
 


### PR DESCRIPTION
Haskell derivations are notoriously large. Putting the final binary into its own output (`bin`) reduces the package closure size from ~1GiB to ~60MiB. The default output for installation is now `cornelis.bin`, but all other build artifacts are still available in `cornelis.out`, cf. [the manual](https://nixos.org/manual/nixpkgs/stable/#haskell-packaging-helpers).