### PR TITLE
Fix testsuite

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -96,5 +96,5 @@ jobs:
             if [ $RUNNER_OS = "Windows" ]; then
              stack test
             else
-              nix shell nixpkgs#agda nixpkgs#neovim -c stack test
+              nix shell -c stack test
             fi

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,18 @@
+# Working on cornelis
+
+The project can be built and tested with both `stack` and `cabal`.  In order to
+successfully run the test suite, both `agda` and `nvim` need to be on `$PATH`.
+
+## Development using Nix
+
+Nix integration is provided in the form of a Nix Flake.  To build the project,
+simply run `nix build`.  For interactive development, use the provided shell:
+
+```sh
+# Launch a shell with all development dependencies installed
+# (cabal, system libraries, etc.):
+nix develop
+
+# Run tests from a shell that includes a Neovim binary:
+nix develop --command cabal test
+```

--- a/cornelis.cabal
+++ b/cornelis.cabal
@@ -97,8 +97,7 @@ library
       TypeSynonymInstances
   ghc-options: -Wall
   build-depends:
-      QuickCheck >=2.14.2
-    , aeson >=1.5.6.0
+      aeson >=1.5.6.0
     , async
     , base >=4.7 && <5
     , bytestring
@@ -108,9 +107,7 @@ library
     , filepath
     , fingertree >=0.1.4.2
     , generic-lens >=2.1.0.0
-    , hspec >=2.7.10
     , lens >=4.19.2
-    , levenshtein >=0.1.3.0
     , megaparsec >=9.0.1 && <10
     , mtl
     , nvim-hs >=2.2.0.3 && <3
@@ -181,8 +178,7 @@ executable cornelis
       TypeSynonymInstances
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      QuickCheck >=2.14.2
-    , aeson >=1.5.6.0
+      aeson >=1.5.6.0
     , async
     , base >=4.7 && <5
     , bytestring
@@ -193,9 +189,7 @@ executable cornelis
     , filepath
     , fingertree >=0.1.4.2
     , generic-lens >=2.1.0.0
-    , hspec >=2.7.10
     , lens >=4.19.2
-    , levenshtein >=0.1.3.0
     , megaparsec >=9.0.1 && <10
     , mtl
     , nvim-hs >=2.2.0.3 && <3

--- a/cornelis.cabal
+++ b/cornelis.cabal
@@ -104,6 +104,7 @@ library
     , containers
     , diff-loc >=0.1.0.0
     , directory
+    , either ==5.*
     , filepath
     , fingertree >=0.1.4.2
     , generic-lens >=2.1.0.0
@@ -186,6 +187,7 @@ executable cornelis
     , cornelis
     , diff-loc >=0.1.0.0
     , directory
+    , either ==5.*
     , filepath
     , fingertree >=0.1.4.2
     , generic-lens >=2.1.0.0
@@ -273,6 +275,7 @@ test-suite test
     , cornelis
     , diff-loc >=0.1.0.0
     , directory
+    , either ==5.*
     , filepath
     , fingertree >=0.1.4.2
     , generic-lens >=2.1.0.0

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711231723,
-        "narHash": "sha256-dARJQ8AJOv6U+sdRePkbcVyVbXJTi1tReCrkkOeusiA=",
+        "lastModified": 1715867414,
+        "narHash": "sha256-cu4UEffKkBByyGR6CFs9XP6iSNsKTkq1r66DA5BkYnE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e1d501922fd7351da4200e1275dfcf5faaad1220",
+        "rev": "bf446f08bff6814b569265bef8374cfdd3d8f0e0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,7 @@
           default = app.cornelis;
         };
         defaultApp = app.default;
+        devShells.default = pkgs.callPackage ./nix/dev-shells.nix { };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
         };
         agda = pkgs.agda.withPackages (p: [ p.standard-library ]);
       in
-      {
+      rec {
         packages = {
           inherit agda;
           ${name} = pkgs.${name};
@@ -70,6 +70,14 @@
           (v: { name = "${name}-${v}"; value = pkgs.haskell.packages.${v}.${name}; })
           ghcVersions
         );
+        defaultPackage = packages.default;
+        app = {
+          cornelis = inputs.flake-utils.lib.mkApp {
+            inherit name; drv = packages.default;
+          };
+          default = app.cornelis;
+        };
+        defaultApp = app.default;
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -22,11 +22,16 @@
           haskell = prev.haskell // {
             packageOverrides = final.lib.composeExtensions
               prev.haskell.packageOverrides
-              (hfinal: hprev: {
+              (hfinal: hprev: let
+                inherit (final.haskell.lib.compose) enableSeparateBinOutput addTestToolDepends;
+                inherit (final.lib) pipe;
+              in {
                 # Put binaries into separate output "bin" to reduce closure size.
                 # https://nixos.org/manual/nixpkgs/stable/#haskell-packaging-helpers
-                ${name} = final.haskell.lib.enableSeparateBinOutput
-                  (hfinal.callCabal2nix name ./. { });
+                ${name} = pipe (hfinal.callCabal2nix name ./. { }) [
+                  enableSeparateBinOutput
+                  (addTestToolDepends [ final.agda final.neovim ])
+                ];
               });
           };
 

--- a/nix/dev-shells.nix
+++ b/nix/dev-shells.nix
@@ -1,14 +1,27 @@
 {
   path,
   lib,
+  makeWrapper,
+  symlinkJoin,
 
   haskellPackages,
   pkg-config,
+  stack,
   zlib,
   icu,
 }:
 let
+  stack-nix = symlinkJoin {
+    name = "stack-nix";
+    paths = [ (lib.getBin stack) ];
+    nativeBuildInputs = [ makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/stack \
+        --append-flags "--nix --no-nix-pure"
+    '';
+  };
   buildInputs = [
+    stack-nix
     haskellPackages.cabal-install
     pkg-config
     zlib.dev

--- a/nix/dev-shells.nix
+++ b/nix/dev-shells.nix
@@ -1,0 +1,29 @@
+{
+  path,
+  lib,
+
+  haskellPackages,
+  pkg-config,
+  zlib,
+  icu,
+}:
+let
+  buildInputs = [
+    haskellPackages.cabal-install
+    pkg-config
+    zlib.dev
+    zlib.out
+    icu
+  ];
+in
+haskellPackages.shellFor {
+  inherit buildInputs;
+
+  packages = p: [ p.cornelis ];
+
+  # Ensure nix commands do not use the global <nixpkgs> channel:
+  NIX_PATH = "nixpkgs=" + path;
+
+  # Ensure system libraries (zlib.so, etc.) are visible to GHC:
+  LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+}

--- a/package.yaml
+++ b/package.yaml
@@ -45,10 +45,6 @@ dependencies:
 - megaparsec >= 9.0.1 && < 10
 - diff-loc >= 0.1.0.0
 
-- hspec >= 2.7.10
-- QuickCheck >= 2.14.2
-- levenshtein >= 0.1.3.0
-
 default-extensions:
   - BangPatterns
   - BinaryLiterals
@@ -128,6 +124,9 @@ tests:
     - hspec
     - temporary
     - filepath
+    - QuickCheck >= 2.14.2
+    - levenshtein >= 0.1.3.0
+
     # build-dependencies:
     # - hspec-discover
 

--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,7 @@ dependencies:
 - random
 - megaparsec >= 9.0.1 && < 10
 - diff-loc >= 0.1.0.0
+- either >= 5 && < 6
 
 default-extensions:
   - BangPatterns

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+( import
+  ( let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  ) { src =  ./.; }
+).shellNix

--- a/src/Cornelis/Vim.hs
+++ b/src/Cornelis/Vim.hs
@@ -7,6 +7,7 @@ import           Control.Lens ((%~), _head, _last, (&))
 import           Cornelis.Offsets
 import           Cornelis.Types
 import           Cornelis.Utils (objectToInt, savingCurrentPosition, savingCurrentWindow)
+import           Data.Either.Combinators (rightToMaybe)
 import           Data.Foldable (toList)
 import           Data.Int
 import qualified Data.Map as M
@@ -138,6 +139,11 @@ getExtmarkIntervalById ns b (Extmark x) = do
           Just ecol  = toZ $ details M.! ObjectString "end_col"
       fmap Just $ traverse (unvimify b) $ Interval (Pos sline scol) $ Pos eline ecol
     _ -> pure Nothing
+
+getreg :: Text -> Neovim env (Maybe Text)
+getreg reg
+    = (rightToMaybe . fromObject)
+    <$> (vim_call_function "getreg" $ V.singleton $ toObject reg)
 
 ------------------------------------------------------------------------------
 -- | Awful function that does the motion in visual mode and gives you back

--- a/test/TestSpec.hs
+++ b/test/TestSpec.hs
@@ -24,7 +24,7 @@ broken :: String -> SpecWith a -> SpecWith a
 broken = before_ . pendingWith
 
 spec :: Spec
-spec = focus $ do
+spec = focus $ parallel $ do
   let timeout = Seconds 60
 
   executableSpec "agda"

--- a/test/TestSpec.hs
+++ b/test/TestSpec.hs
@@ -27,6 +27,9 @@ spec :: Spec
 spec = focus $ do
   let timeout = Seconds 60
 
+  executableSpec "agda"
+  executableSpec "nvim"
+
   it "should load read-only file" $ do
     withVim timeout $ \w b -> do
       env <- cornelisInit

--- a/test/TestSpec.hs
+++ b/test/TestSpec.hs
@@ -4,7 +4,6 @@
 module TestSpec where
 
 import           Control.Concurrent (threadDelay)
-import           Control.Monad (void)
 import           Cornelis.Subscripts (decNextDigitSeq, incNextDigitSeq)
 import           Cornelis.Types
 import           Cornelis.Types.Agda (Rewrite (..))
@@ -41,12 +40,12 @@ spec = focus $ do
     goto w 11 8
     refine
 
-  broken "Times out in CI for unknown reasons" $ diffSpec "should support helper functions" timeout "test/Hello.agda"
-      [ Swap "" "help_me : Unit"] $ \w _ -> do
+  vimSpec "should support helper functions" timeout "test/Hello.agda" $ \w _ -> do
     goto w 11 8
     helperFunc Normalised "help_me"
     liftIO $ threadDelay 5e5
-    void $ vim_command "normal! G\"\"p"
+    reg <- getreg "\""
+    liftIO $ reg `shouldBe` Just "help_me : Unit"
 
   diffSpec "should case split (unicode lambda)" timeout "test/Hello.agda"
       [ Add                       "slap = λ { true → {! !}"

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -104,7 +104,7 @@ vimSpec name secs fp m = do
       withNeovimEmbedded secs $ do
         env <- cornelisInit
         withLocalEnv env $ do
-          vim_command $ "edit " <> T.pack fp'
+          nvim_command $ "noswap edit " <> T.pack fp'
           liftIO $ threadDelay 1e6
           w <- vim_get_current_window
           b <- nvim_win_get_buf w

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -19,9 +19,11 @@ import           Neovim
 import           Neovim.API.Text
 import           Neovim.Test
 import           Plugin
+import           System.Exit (ExitCode(..))
 import           System.FilePath (takeBaseName)
 import           System.IO (hFlush, hPutStr)
 import           System.IO.Temp (withSystemTempFile)
+import           System.Process (rawSystem)
 import           Test.Hspec hiding (after, before)
 
 
@@ -108,6 +110,13 @@ vimSpec name secs fp m = do
           load
           liftIO $ threadDelay 5e6
           m w b
+
+-- | Assert that 'bin' is executable.
+executableSpec :: String -> Spec
+executableSpec bin = describe bin $ do
+  it "is executable" $ do
+    exit_code <- rawSystem bin ["--version"]
+    exit_code `shouldBe` ExitSuccess
 
 goto :: Window -> Int -> Int -> Neovim env ()
 goto w row col = setWindowCursor w $ Pos (toOneIndexed row) (toOneIndexed col)


### PR DESCRIPTION
I've had these commits laying around locally for a while. I've attempted to fix the testsuite when running it under Nix, especially by ensuring that both `nvim` and `agda` are available to the tests. Now CI at least fails with some reasonable errors instead of reporting "no `nvim` in $PATH" as "all OK".

In particular fe25c8e0182f18469ad6db306cb3e59c2d30e90d, 8f12732689575113829e743ba9cbb86da4837619 and ff67545f82f3c5c442640a940fff4ac0cb9cdd09 could be of interest. But there's other commits in here that are perhaps independently useful. Feel free to cherry-pick anything that's useful.