### PR TITLE
fix datatype syntax highlighting (probably fixes #153)

### DIFF
--- a/src/Cornelis/Pretty.hs
+++ b/src/Cornelis/Pretty.hs
@@ -43,7 +43,7 @@ data HighlightGroup
   | CornelisPositivityProblem -- ^ Failed positivity check
   | CornelisKeyword -- ^ An Agda keywords (@where@, @let@, etc.)
   | CornelisSymbol -- ^ A symbol, not part of an identifier (@=@, @:@, @{@, etc.)
-  | CornelisType -- ^ A datatype (@Nat@, @Bool@, etc.)
+  | CornelisDatatype -- ^ A datatype (@Nat@, @Bool@, etc.)
   | CornelisPrimitiveType -- ^ A primitive/builtin Agda type
   | CornelisRecord -- ^ A datatype, defined as a @record@
   | CornelisFunction -- ^ A function, e.g. a top-level declaration
@@ -134,7 +134,7 @@ renderWithHlGroups = go [] 0 0
 
 
 prettyType :: C.Type -> Doc HighlightGroup
-prettyType (C.Type ty) = annotate CornelisType $ sep $ fmap pretty $ T.lines ty
+prettyType (C.Type ty) = annotate CornelisDatatype $ sep $ fmap pretty $ T.lines ty
 
 
 groupScopeSet :: [InScope] -> [[InScope]]
@@ -171,7 +171,7 @@ prettyGoals (GoalSpecific _ scoped ty mhave mboundary mconstraints) =
 prettyGoals (HelperFunction sig) =
   section "Helper Function"
     [ mempty
-    , annotate CornelisType $ pretty sig
+    , annotate CornelisDatatype $ pretty sig
     , mempty
     , annotate CornelisComment $ parens "copied to \" register"
     ] id

--- a/syntax/agda.vim
+++ b/syntax/agda.vim
@@ -33,8 +33,8 @@ hi def link CornelisTypeChecks           CornelisWarn
 hi def link CornelisKeyword              Keyword
 hi def link CornelisSymbol               Normal
 
-hi def link CornelisType                 Type
-hi def link CornelisRecord               CornelisType
+hi def link CornelisDatatype             Type
+hi def link CornelisRecord               CornelisDatatype
 
 hi def link CornelisModule               Constant
 


### PR DESCRIPTION
Agda returns 'datatype', not 'type', as the name of datatypes. CornelisType in Pretty.hs will not apply to these (via toAtomName) unless it's named CornelisDatatype.

This is the simplest fix. One could add a CornelisType syntax group that both CornelisDatatype and CornelisRecord link to, which might be a little more backwards-compatible with people who do highlight linking around CornelisType. But my guess is that CornelisType has never worked (see #153) and so I'm not worrying about backwards compatibility.