### PR TITLE
Remove {} from iskeyword

### DIFF
--- a/ftplugin/agda.vim
+++ b/ftplugin/agda.vim
@@ -4,7 +4,7 @@ setlocal formatoptions+=croql
 setlocal comments=sfl:{-,mb1:--,ex:-},:--
 setlocal commentstring=--\ %s
 
-setlocal iskeyword=@,!-~,^.,_,^\(,^\),^\",^\',192-255
+setlocal iskeyword=@,!-~,^.,_,^\(,^\),^{,^},^\",^\',192-255
 
 if exists("b:cornelis_ftplugin")
   finish

--- a/src/Cornelis/Pretty.hs
+++ b/src/Cornelis/Pretty.hs
@@ -43,7 +43,7 @@ data HighlightGroup
   | CornelisPositivityProblem -- ^ Failed positivity check
   | CornelisKeyword -- ^ An Agda keywords (@where@, @let@, etc.)
   | CornelisSymbol -- ^ A symbol, not part of an identifier (@=@, @:@, @{@, etc.)
-  | CornelisType -- ^ A datatype (@Nat@, @Bool@, etc.)
+  | CornelisDatatype -- ^ A datatype (@Nat@, @Bool@, etc.)
   | CornelisPrimitiveType -- ^ A primitive/builtin Agda type
   | CornelisRecord -- ^ A datatype, defined as a @record@
   | CornelisFunction -- ^ A function, e.g. a top-level declaration
@@ -134,7 +134,7 @@ renderWithHlGroups = go [] 0 0
 
 
 prettyType :: C.Type -> Doc HighlightGroup
-prettyType (C.Type ty) = annotate CornelisType $ sep $ fmap pretty $ T.lines ty
+prettyType (C.Type ty) = annotate CornelisDatatype $ sep $ fmap pretty $ T.lines ty
 
 
 groupScopeSet :: [InScope] -> [[InScope]]
@@ -171,7 +171,7 @@ prettyGoals (GoalSpecific _ scoped ty mhave mboundary mconstraints) =
 prettyGoals (HelperFunction sig) =
   section "Helper Function"
     [ mempty
-    , annotate CornelisType $ pretty sig
+    , annotate CornelisDatatype $ pretty sig
     , mempty
     , annotate CornelisComment $ parens "copied to \" register"
     ] id

--- a/syntax/agda.vim
+++ b/syntax/agda.vim
@@ -33,8 +33,8 @@ hi def link CornelisTypeChecks           CornelisWarn
 hi def link CornelisKeyword              Keyword
 hi def link CornelisSymbol               Normal
 
-hi def link CornelisType                 Type
-hi def link CornelisRecord               CornelisType
+hi def link CornelisDatatype             Type
+hi def link CornelisRecord               CornelisDatatype
 
 hi def link CornelisModule               Constant
 


### PR DESCRIPTION
Removes curly braces from iskeyword. Probably unicode ranges should also be added to iskeyword so that symbols like ≡ are recognized by (n)vim as legal parts of names, but I can't be bothered to check what unicode ranges to add or how unicode ranges in iskeyword interact with the file encoding (to make sure it works cross-platform), and this is a quick and easy fix.