### PR TITLE
parenthesize for CornelisSolve

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -74,7 +74,7 @@ respond b (GiveAction result ip) = do
     Nothing -> reportError $ T.pack $ "Can't find interaction point " <> show i
     Just ip' -> do
       int <- getIpInterval b ip'
-      replaceInterval b int $ parenthesize $ replaceQuestion result
+      replaceInterval b int $ replaceQuestion result
   load
 -- Replace the interaction point with a result
 respond b (SolveAll solutions) = do

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -45,6 +45,12 @@ respondToHelperFunction (HelperFunction sig) = setreg "\"" sig
 respondToHelperFunction (Version ver) = reportInfo ver
 respondToHelperFunction _ = pure ()
 
+parenthesize :: Text -> Text
+parenthesize t =
+  let trimmed = T.strip t
+   in if T.any (== ' ') trimmed && not (T.isPrefixOf "(" trimmed && T.isSuffixOf ")" trimmed)
+        then "(" <> trimmed <> ")"
+        else trimmed
 
 respond :: Buffer -> Response -> Neovim CornelisEnv ()
 -- Update the buffer's goal map
@@ -68,7 +74,7 @@ respond b (GiveAction result ip) = do
     Nothing -> reportError $ T.pack $ "Can't find interaction point " <> show i
     Just ip' -> do
       int <- getIpInterval b ip'
-      replaceInterval b int $ replaceQuestion result
+      replaceInterval b int $ parenthesize $ replaceQuestion result
   load
 -- Replace the interaction point with a result
 respond b (SolveAll solutions) = do
@@ -77,7 +83,7 @@ respond b (SolveAll solutions) = do
       Nothing -> reportError $ T.pack $ "Can't find interaction point " <> show i
       Just ip -> do
         int <- getIpInterval b ip
-        replaceInterval b int $ replaceQuestion ex
+        replaceInterval b int $ parenthesize $ replaceQuestion ex
   load
 respond b ClearHighlighting = do
   -- delete what we know about goto positions and stored extmarks


### PR DESCRIPTION
I noticed that when I use CornelisSolve (most of the time) the result that is inputted automatically is not parenthesized. An example of such behaviour can be found in a [course-lab](https://github.com/leo-leesco/hott/blob/main/HLevels.agda) I was working on.

Situation :
```agda
isPropIsOfHLevel : {A : Type ℓ} (n : HLevel) → isProp (isOfHLevel n A)
isPropIsOfHLevel zero = isPropIsContr
isPropIsOfHLevel (suc n) p q = funExt λ { x → funExt λ { y → isPropIsOfHLevel n (p x y) {!q !} } }
```

Expected result :
```agda
isPropIsOfHLevel : {A : Type ℓ} (n : HLevel) → isProp (isOfHLevel n A)
isPropIsOfHLevel zero = isPropIsContr
isPropIsOfHLevel (suc n) p q = funExt λ { x → funExt λ { y → isPropIsOfHLevel n (p x y) (q x y) } }
```

Actual result :
```agda
isPropIsOfHLevel : {A : Type ℓ} (n : HLevel) → isProp (isOfHLevel n A)
isPropIsOfHLevel zero = isPropIsContr
isPropIsOfHLevel (suc n) p q = funExt λ { x → funExt λ { y → isPropIsOfHLevel n (p x y) q x y } }
```

And rightfully enough, Agda complains about that because it is ill-typed…

I know just about nothing regarding Haskell, so :
- the few lines I added might be outright antipatterns
- I'd be very happy if you could help me improve/explain a little what is the correct mechanism to handle what I did (or if there is any)
- if this was the right thing to do, maybe explain if there should have been a better way to write that ?

Anyway, it seems like this fixes the bug, I'm not sure it did not introduce any other.
Best,
Léo
PS: btw, thank you for this absolute of a banger of a plugin. I mean it, it's absolutely great ! Apart from this little inconvenience, it's more or less perfect